### PR TITLE
Clean up frontend: remove duplicate CSS, standardize scripts, fix favicon

### DIFF
--- a/astro-frontend/src/components/ContentCard.astro
+++ b/astro-frontend/src/components/ContentCard.astro
@@ -259,153 +259,160 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
 </style>
 
 <script>
-  // Simple IIFE - plain JavaScript for maximum compatibility
-  (function initContentCard() {
-    const card = document.getElementById('content-card');
-    if (!card) return;
+  interface Article {
+    title?: string;
+    link?: string;
+    source?: string;
+    pub_date?: string;
+  }
 
-    const apiUrl = card.getAttribute('data-api-url') || 'http://localhost:8000/api/v1';
+  class ContentCard {
+    private card: HTMLElement | null = null;
+    private apiUrl = '';
+    private sport: string | null = null;
+    private type: string | null = null;
+    private id: string | null = null;
 
-    // Parse URL params
-    const params = new URLSearchParams(window.location.search);
-    const sport = params.get('sport');
-    const type = params.get('type');
-    const id = params.get('id');
+    private loadingEl: HTMLElement | null = null;
+    private contentEl: HTMLElement | null = null;
+    private listEl: HTMLElement | null = null;
+    private emptyEl: HTMLElement | null = null;
 
-    // Elements
-    const loadingEl = document.getElementById('articles-loading');
-    const contentEl = document.getElementById('articles-content');
-    const listEl = document.getElementById('articles-list');
-    const emptyEl = document.getElementById('articles-empty');
+    constructor() {
+      const card = document.getElementById('content-card');
+      if (!card) return;
 
-    // Tab switching
-    document.querySelectorAll('.tab-btn').forEach(function(btn) {
-      btn.addEventListener('click', function() {
-        const tab = this.getAttribute('data-tab');
-        
-        // Update buttons
-        document.querySelectorAll('.tab-btn').forEach(function(b) {
-          b.classList.remove('active');
-        });
-        this.classList.add('active');
-        
-        // Update panels
-        document.querySelectorAll('.tab-content').forEach(function(p) {
-          p.classList.remove('active');
-        });
-        const panel = document.getElementById(tab + '-tab');
-        if (panel) panel.classList.add('active');
-      });
-    });
+      this.card = card;
+      this.apiUrl = card.dataset.apiUrl || 'http://localhost:8000/api/v1';
 
-    // Validate params
-    if (!sport || !type || !id) {
-      showEmpty();
-      return;
+      const params = new URLSearchParams(window.location.search);
+      this.sport = params.get('sport');
+      this.type = params.get('type');
+      this.id = params.get('id');
+
+      this.loadingEl = document.getElementById('articles-loading');
+      this.contentEl = document.getElementById('articles-content');
+      this.listEl = document.getElementById('articles-list');
+      this.emptyEl = document.getElementById('articles-empty');
+
+      this.init();
     }
 
-    // Step 1: Get entity name from widget endpoint (cached for 30 days, so fast)
-    // Step 2: Use entity name to fetch news
-    var widgetUrl = apiUrl + '/widget/' + type + '/' + id + '?sport=' + sport.toUpperCase();
-    console.log('[ContentCard] Fetching widget for name:', widgetUrl);
+    private init() {
+      this.bindTabEvents();
 
-    fetch(widgetUrl)
-      .then(function(res) {
-        if (!res.ok) throw new Error('Widget HTTP ' + res.status);
-        return res.json();
-      })
-      .then(function(widgetData) {
-        // Get entity name from widget response
-        var entityName = '';
-        if (widgetData.team) {
-          entityName = widgetData.team.name;
-        } else if (widgetData.player) {
-          entityName = widgetData.player.name;
-        } else {
-          entityName = widgetData.name;
-        }
-        
+      if (!this.sport || !this.type || !this.id) {
+        this.showEmpty();
+        return;
+      }
+
+      this.fetchData();
+    }
+
+    private bindTabEvents() {
+      if (!this.card) return;
+      this.card.querySelectorAll('.tab-btn').forEach(btn => {
+        btn.addEventListener('click', (e) => {
+          const target = e.currentTarget as HTMLButtonElement;
+          const tab = target.dataset.tab;
+
+          this.card!.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+          target.classList.add('active');
+
+          this.card!.querySelectorAll('.tab-content').forEach(p => p.classList.remove('active'));
+          const panel = document.getElementById(`${tab}-tab`);
+          if (panel) panel.classList.add('active');
+        });
+      });
+    }
+
+    private async fetchData() {
+      const widgetUrl = `${this.apiUrl}/widget/${this.type}/${this.id}?sport=${this.sport!.toUpperCase()}`;
+      console.log('[ContentCard] Fetching widget for name:', widgetUrl);
+
+      try {
+        const widgetRes = await fetch(widgetUrl);
+        if (!widgetRes.ok) throw new Error(`Widget HTTP ${widgetRes.status}`);
+        const widgetData = await widgetRes.json();
+
+        const entityName = widgetData.team?.name || widgetData.player?.name || widgetData.name;
         if (!entityName) {
-          showEmpty();
+          this.showEmpty();
           return;
         }
 
-        // Fetch news using entity name
-        var newsUrl = apiUrl + '/news/' + encodeURIComponent(entityName);
+        const newsUrl = `${this.apiUrl}/news/${encodeURIComponent(entityName)}`;
         console.log('[ContentCard] Fetching news:', newsUrl);
 
-        return fetch(newsUrl);
-      })
-      .then(function(res) {
-        if (!res) return null;
-        console.log('[ContentCard] News response status:', res.status);
-        if (!res.ok) throw new Error('News HTTP ' + res.status);
-        return res.json();
-      })
-      .then(function(data) {
-        if (!data) return;
+        const newsRes = await fetch(newsUrl);
+        console.log('[ContentCard] News response status:', newsRes.status);
+        if (!newsRes.ok) throw new Error(`News HTTP ${newsRes.status}`);
+
+        const data = await newsRes.json();
         console.log('[ContentCard] News data:', data);
-        var articles = data.articles || [];
-        
+
+        const articles: Article[] = data.articles || [];
         if (articles.length === 0) {
-          showEmpty();
+          this.showEmpty();
           return;
         }
 
-        // Render articles as simple HTML
-        var html = '';
-        for (var i = 0; i < articles.length; i++) {
-          html += renderArticle(articles[i]);
-        }
-        listEl.innerHTML = html;
-        showContent();
-      })
-      .catch(function(err) {
+        this.renderArticles(articles);
+      } catch (err) {
         console.error('[ContentCard] Error:', err);
-        showEmpty();
-      });
-
-    function renderArticle(article) {
-      var title = escapeHtml(article.title || 'Untitled');
-      var link = article.link || '#';
-      var source = escapeHtml(article.source || '');
-      var date = formatDate(article.pub_date);
-      
-      return '<div class="content-item">' +
-        '<h3 class="content-title">' +
-          '<a href="' + link + '" target="_blank" rel="noopener">' + title + '</a>' +
-        '</h3>' +
-        '<div class="content-meta">' + source + (source && date ? ' · ' : '') + date + '</div>' +
-      '</div>';
+        this.showEmpty();
+      }
     }
 
-    function escapeHtml(str) {
+    private renderArticles(articles: Article[]) {
+      const html = articles.map(article => this.renderArticle(article)).join('');
+      if (this.listEl) this.listEl.innerHTML = html;
+      this.showContent();
+    }
+
+    private renderArticle(article: Article): string {
+      const title = this.escapeHtml(article.title || 'Untitled');
+      const link = article.link || '#';
+      const source = this.escapeHtml(article.source || '');
+      const date = this.formatDate(article.pub_date);
+
+      return `<div class="content-item">
+        <h3 class="content-title">
+          <a href="${link}" target="_blank" rel="noopener">${title}</a>
+        </h3>
+        <div class="content-meta">${source}${source && date ? ' · ' : ''}${date}</div>
+      </div>`;
+    }
+
+    private escapeHtml(str: string): string {
       if (!str) return '';
-      var div = document.createElement('div');
+      const div = document.createElement('div');
       div.textContent = str;
       return div.innerHTML;
     }
 
-    function formatDate(dateStr) {
+    private formatDate(dateStr?: string): string {
       if (!dateStr) return '';
       try {
-        var d = new Date(dateStr);
+        const d = new Date(dateStr);
         return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-      } catch (e) {
+      } catch {
         return '';
       }
     }
 
-    function showContent() {
-      if (loadingEl) loadingEl.classList.add('hidden');
-      if (contentEl) contentEl.classList.remove('hidden');
-      if (emptyEl) emptyEl.classList.add('hidden');
+    private showContent() {
+      this.loadingEl?.classList.add('hidden');
+      this.contentEl?.classList.remove('hidden');
+      this.emptyEl?.classList.add('hidden');
     }
 
-    function showEmpty() {
-      if (loadingEl) loadingEl.classList.add('hidden');
-      if (contentEl) contentEl.classList.add('hidden');
-      if (emptyEl) emptyEl.classList.remove('hidden');
+    private showEmpty() {
+      this.loadingEl?.classList.add('hidden');
+      this.contentEl?.classList.add('hidden');
+      this.emptyEl?.classList.remove('hidden');
     }
-  })();
+  }
+
+  new ContentCard();
 </script>

--- a/astro-frontend/src/components/EntityWidget.astro
+++ b/astro-frontend/src/components/EntityWidget.astro
@@ -166,118 +166,130 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
 </style>
 
 <script>
-  // Simple IIFE - plain JavaScript, no TypeScript
-  (function initEntityWidget() {
-    var widget = document.getElementById('entity-widget');
-    if (!widget) return;
+  class EntityWidget {
+    private widget: HTMLElement | null = null;
+    private apiUrl = '';
+    private buttonDest = '';
+    private sport: string | null = null;
+    private type: string | null = null;
+    private id: string | null = null;
 
-    var apiUrl = widget.getAttribute('data-api') || 'http://localhost:8000/api/v1';
-    var buttonDest = widget.getAttribute('data-dest') || 'mentions';
+    private loadingEl: HTMLElement | null = null;
+    private contentEl: HTMLElement | null = null;
+    private errorEl: HTMLElement | null = null;
+    private nameEl: HTMLElement | null = null;
+    private badgeEl: HTMLElement | null = null;
+    private subtitleEl: HTMLElement | null = null;
+    private logoEl: HTMLImageElement | null = null;
+    private buttonEl: HTMLAnchorElement | null = null;
 
-    // Parse URL params
-    var params = new URLSearchParams(window.location.search);
-    var sport = params.get('sport');
-    var type = params.get('type');
-    var id = params.get('id');
+    constructor() {
+      const widget = document.getElementById('entity-widget');
+      if (!widget) return;
 
-    // Elements
-    var loadingEl = document.getElementById('ew-loading');
-    var contentEl = document.getElementById('ew-content');
-    var errorEl = document.getElementById('ew-error');
-    var nameEl = document.getElementById('ew-name');
-    var badgeEl = document.getElementById('ew-badge');
-    var subtitleEl = document.getElementById('ew-subtitle');
-    var logoEl = document.getElementById('ew-logo');
-    var buttonEl = document.getElementById('ew-button');
+      this.widget = widget;
+      this.apiUrl = widget.dataset.api || 'http://localhost:8000/api/v1';
+      this.buttonDest = widget.dataset.dest || 'mentions';
 
-    // Set button href immediately
-    if (sport && type && id && buttonEl) {
-      buttonEl.href = '/' + buttonDest + '?sport=' + sport + '&type=' + type + '&id=' + id;
+      const params = new URLSearchParams(window.location.search);
+      this.sport = params.get('sport');
+      this.type = params.get('type');
+      this.id = params.get('id');
+
+      this.loadingEl = document.getElementById('ew-loading');
+      this.contentEl = document.getElementById('ew-content');
+      this.errorEl = document.getElementById('ew-error');
+      this.nameEl = document.getElementById('ew-name');
+      this.badgeEl = document.getElementById('ew-badge');
+      this.subtitleEl = document.getElementById('ew-subtitle');
+      this.logoEl = document.getElementById('ew-logo') as HTMLImageElement;
+      this.buttonEl = document.getElementById('ew-button') as HTMLAnchorElement;
+
+      this.init();
     }
 
-    // Validate params
-    if (!sport || !type || !id) {
-      showError();
-      return;
+    private init() {
+      if (this.sport && this.type && this.id && this.buttonEl) {
+        this.buttonEl.href = `/${this.buttonDest}?sport=${this.sport}&type=${this.type}&id=${this.id}`;
+      }
+
+      if (!this.sport || !this.type || !this.id) {
+        this.showError();
+        return;
+      }
+
+      this.fetchData();
     }
 
-    // Fetch from simple widget endpoint
-    var url = apiUrl + '/widget/' + type + '/' + id + '?sport=' + sport.toUpperCase();
-    console.log('[EntityWidget] Fetching:', url);
+    private async fetchData() {
+      const url = `${this.apiUrl}/widget/${this.type}/${this.id}?sport=${this.sport!.toUpperCase()}`;
+      console.log('[EntityWidget] Fetching:', url);
 
-    fetch(url)
-      .then(function(res) {
+      try {
+        const res = await fetch(url);
         console.log('[EntityWidget] Response status:', res.status);
-        if (!res.ok) throw new Error('HTTP ' + res.status);
-        return res.json();
-      })
-      .then(function(data) {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+        const data = await res.json();
         console.log('[EntityWidget] Data:', data);
-        
+
         if (data.error) {
-          showError();
+          this.showError();
           return;
         }
-        
-        // API returns EXACTLY what API-Sports returns:
-        // Teams: { team: { id, name, logo, ... }, venue: { name, city, ... } }
-        // Players: { player: { id, name, photo, ... }, statistics: [...] }
-        var name = '';
-        var logo = '';
-        var subtitle = '';
-        
-        if (type === 'team') {
-          // Team response from API-Sports
-          var teamData = data.team || {};
-          var venueData = data.venue || {};
-          
-          name = teamData.name || 'Unknown';
-          logo = teamData.logo || '';
-          subtitle = venueData.name || venueData.city || teamData.country || '';
-        } else {
-          // Player response from API-Sports
-          var playerData = data.player || {};
-          var stats = data.statistics || [];
-          var teamInfo = stats[0] ? stats[0].team : null;
-          
-          name = playerData.name || ((playerData.firstname || '') + ' ' + (playerData.lastname || '')).trim() || 'Unknown';
-          logo = playerData.photo || '';
-          subtitle = teamInfo ? teamInfo.name : '';
-        }
-        
-        // Display name
-        if (nameEl) nameEl.textContent = name;
-        
-        // Badge (type from URL param)
-        if (badgeEl) badgeEl.textContent = type.toUpperCase();
-        
-        // Subtitle
-        if (subtitleEl) subtitleEl.textContent = subtitle;
-        
-        // Logo/photo
-        if (logoEl && logo) {
-          logoEl.src = logo;
-          logoEl.alt = name;
-          logoEl.style.display = 'block';
-        }
-        
-        showContent();
-      })
-      .catch(function(err) {
+
+        this.renderData(data);
+      } catch (err) {
         console.error('[EntityWidget] Error:', err);
-        showError();
-      });
-
-    function showContent() {
-      if (loadingEl) loadingEl.style.display = 'none';
-      if (contentEl) contentEl.style.display = 'flex';
-      if (errorEl) errorEl.style.display = 'none';
+        this.showError();
+      }
     }
 
-    function showError() {
-      if (loadingEl) loadingEl.style.display = 'none';
-      if (contentEl) contentEl.style.display = 'none';
-      if (errorEl) errorEl.style.display = 'flex';
+    private renderData(data: any) {
+      let name = '';
+      let logo = '';
+      let subtitle = '';
+
+      if (this.type === 'team') {
+        const teamData = data.team || {};
+        const venueData = data.venue || {};
+        name = teamData.name || 'Unknown';
+        logo = teamData.logo || '';
+        subtitle = venueData.name || venueData.city || teamData.country || '';
+      } else {
+        const playerData = data.player || {};
+        const stats = data.statistics || [];
+        const teamInfo = stats[0]?.team;
+        name = playerData.name || `${playerData.firstname || ''} ${playerData.lastname || ''}`.trim() || 'Unknown';
+        logo = playerData.photo || '';
+        subtitle = teamInfo?.name || '';
+      }
+
+      if (this.nameEl) this.nameEl.textContent = name;
+      if (this.badgeEl) this.badgeEl.textContent = this.type!.toUpperCase();
+      if (this.subtitleEl) this.subtitleEl.textContent = subtitle;
+
+      if (this.logoEl && logo) {
+        this.logoEl.src = logo;
+        this.logoEl.alt = name;
+        this.logoEl.style.display = 'block';
+      }
+
+      this.showContent();
     }
-  })();
+
+    private showContent() {
+      if (this.loadingEl) this.loadingEl.style.display = 'none';
+      if (this.contentEl) this.contentEl.style.display = 'flex';
+      if (this.errorEl) this.errorEl.style.display = 'none';
+    }
+
+    private showError() {
+      if (this.loadingEl) this.loadingEl.style.display = 'none';
+      if (this.contentEl) this.contentEl.style.display = 'none';
+      if (this.errorEl) this.errorEl.style.display = 'flex';
+    }
+  }
+
+  new EntityWidget();
 </script>

--- a/astro-frontend/src/components/StatsCard.astro
+++ b/astro-frontend/src/components/StatsCard.astro
@@ -182,7 +182,7 @@ const { title, stat } = Astro.props;
   }
 
   // Initialize all stats cards on the page
-  document.querySelectorAll('.stats-card-shell').forEach(shell => {
+  document.querySelectorAll<HTMLElement>('.stats-card-shell').forEach(shell => {
     new StatsCardManager(shell);
   });
 </script>

--- a/astro-frontend/src/layouts/Layout.astro
+++ b/astro-frontend/src/layouts/Layout.astro
@@ -61,8 +61,7 @@ const structuredData = {
     <title>{title}</title>
     
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="/new logo.png" />
-    <link rel="apple-touch-icon" href="/new logo.png" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     
     <!-- Structured Data -->
     <script type="application/ld+json" set:html={JSON.stringify(structuredData)} is:inline></script>

--- a/astro-frontend/src/styles/global.css
+++ b/astro-frontend/src/styles/global.css
@@ -272,28 +272,4 @@
     box-shadow: 0 0 0 3px rgba(97, 175, 239, 0.2);
   }
 
-  .search-input-wrapper {
-    display: flex;
-    align-items: center;
-    background-color: #f3ede6;
-    border-radius: 1rem;
-    padding: 0.5rem 1rem;
-    border: 1px solid #eee8d5;
-    transition: box-shadow 0.15s ease, border-color 0.15s ease;
-  }
-
-  .dark .search-input-wrapper {
-    background-color: #2c2c2c;
-    border-color: #3e3e3e;
-  }
-
-  .search-input-wrapper:focus-within {
-    border-color: #268bd2;
-    box-shadow: 0 0 0 3px rgba(38, 139, 210, 0.15);
-  }
-
-  .dark .search-input-wrapper:focus-within {
-    border-color: var(--cm-blue, #61afef);
-    box-shadow: 0 0 0 3px rgba(86, 182, 194, 0.15);
-  }
 }


### PR DESCRIPTION
- Remove duplicate .search-input-wrapper from global.css (already defined in SearchForm.astro)
- Standardize EntityWidget and ContentCard to use TypeScript class pattern matching other components
- Replace apple-touch-icon with lightweight SVG favicon
- Fix TypeScript strict mode issues with property initialization