### PR TITLE
Add co-mentions feature to find related entities in news articles

### DIFF
--- a/astro-frontend/src/components/ContentCard.astro
+++ b/astro-frontend/src/components/ContentCard.astro
@@ -256,6 +256,49 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
   .hidden {
     display: none;
   }
+
+  /* Co-mentions specific styles */
+  .co-mention-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .co-mention-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .co-mention-name {
+    font-weight: 600;
+    color: #3d3d3d;
+    text-decoration: none;
+    transition: color 0.2s ease;
+  }
+
+  :global(.dark) .co-mention-name {
+    color: #e8e8e8;
+  }
+
+  .co-mention-name:hover {
+    color: #d4a574;
+  }
+
+  .co-mention-count {
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: #fff;
+    background-color: #d4a574;
+    padding: 0.2rem 0.6rem;
+    border-radius: 12px;
+    white-space: nowrap;
+  }
+
+  :global(.dark) .co-mention-count {
+    background-color: #b8956a;
+  }
 </style>
 
 <script>
@@ -266,6 +309,13 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
     pub_date?: string;
   }
 
+  interface CoMention {
+    entity_type: string;
+    entity_id: number;
+    name: string;
+    mention_count: number;
+  }
+
   class ContentCard {
     private card: HTMLElement | null = null;
     private apiUrl = '';
@@ -273,10 +323,18 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
     private type: string | null = null;
     private id: string | null = null;
 
+    // Articles tab elements
     private loadingEl: HTMLElement | null = null;
     private contentEl: HTMLElement | null = null;
     private listEl: HTMLElement | null = null;
     private emptyEl: HTMLElement | null = null;
+
+    // Co-mentions tab elements
+    private coMentionsLoadingEl: HTMLElement | null = null;
+    private coMentionsContentEl: HTMLElement | null = null;
+    private coMentionsListEl: HTMLElement | null = null;
+    private coMentionsEmptyEl: HTMLElement | null = null;
+    private coMentionsLoaded = false;
 
     constructor() {
       const card = document.getElementById('content-card');
@@ -294,6 +352,12 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
       this.contentEl = document.getElementById('articles-content');
       this.listEl = document.getElementById('articles-list');
       this.emptyEl = document.getElementById('articles-empty');
+
+      // Initialize co-mentions elements
+      this.coMentionsLoadingEl = document.getElementById('co-mentions-loading');
+      this.coMentionsContentEl = document.getElementById('co-mentions-content');
+      this.coMentionsListEl = document.getElementById('co-mentions-list');
+      this.coMentionsEmptyEl = document.getElementById('co-mentions-empty');
 
       this.init();
     }
@@ -322,6 +386,11 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
           this.card!.querySelectorAll('.tab-content').forEach(p => p.classList.remove('active'));
           const panel = document.getElementById(`${tab}-tab`);
           if (panel) panel.classList.add('active');
+
+          // Lazy-load co-mentions when tab is clicked
+          if (tab === 'co-mentions' && !this.coMentionsLoaded) {
+            this.fetchCoMentions();
+          }
         });
       });
     }
@@ -411,6 +480,75 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
       this.loadingEl?.classList.add('hidden');
       this.contentEl?.classList.add('hidden');
       this.emptyEl?.classList.remove('hidden');
+    }
+
+    // Co-mentions methods
+    private async fetchCoMentions() {
+      if (!this.sport || !this.type || !this.id) {
+        this.showCoMentionsEmpty();
+        return;
+      }
+
+      const url = `${this.apiUrl}/co-mentions/${this.type}/${this.id}?sport=${this.sport.toUpperCase()}`;
+      console.log('[ContentCard] Fetching co-mentions:', url);
+
+      try {
+        const res = await fetch(url);
+        console.log('[ContentCard] Co-mentions response status:', res.status);
+        if (!res.ok) throw new Error(`Co-mentions HTTP ${res.status}`);
+
+        const data = await res.json();
+        console.log('[ContentCard] Co-mentions data:', data);
+
+        const coMentions: CoMention[] = data.co_mentions || [];
+        this.coMentionsLoaded = true;
+
+        if (coMentions.length === 0) {
+          this.showCoMentionsEmpty();
+          return;
+        }
+
+        this.renderCoMentions(coMentions);
+      } catch (err) {
+        console.error('[ContentCard] Co-mentions error:', err);
+        this.showCoMentionsEmpty();
+      }
+    }
+
+    private renderCoMentions(coMentions: CoMention[]) {
+      const html = coMentions.map(cm => this.renderCoMention(cm)).join('');
+      if (this.coMentionsListEl) this.coMentionsListEl.innerHTML = html;
+      this.showCoMentionsContent();
+    }
+
+    private renderCoMention(cm: CoMention): string {
+      const name = this.escapeHtml(cm.name);
+      const type = cm.entity_type === 'player' ? 'Player' : 'Team';
+      const count = cm.mention_count;
+      const countLabel = count === 1 ? 'mention' : 'mentions';
+
+      // Build link to the entity's mentions page
+      const link = `/mentions?sport=${this.sport}&type=${cm.entity_type}&id=${cm.entity_id}`;
+
+      return `<div class="content-item co-mention-item">
+        <div class="co-mention-header">
+          <a href="${link}" class="co-mention-name">${name}</a>
+          <span class="co-mention-count">${count} ${countLabel}</span>
+        </div>
+        <div class="content-meta">${type}</div>
+      </div>`;
+    }
+
+    private showCoMentionsContent() {
+      this.coMentionsLoadingEl?.classList.add('hidden');
+      this.coMentionsContentEl?.classList.remove('hidden');
+      this.coMentionsEmptyEl?.classList.add('hidden');
+    }
+
+    private showCoMentionsEmpty() {
+      this.coMentionsLoadingEl?.classList.add('hidden');
+      this.coMentionsContentEl?.classList.add('hidden');
+      this.coMentionsEmptyEl?.classList.remove('hidden');
     }
   }
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,7 +14,7 @@ from fastapi.responses import JSONResponse
 from fastapi import Request, HTTPException
 
 from app.config import settings
-from app.routers import widgets, news, twitter, reddit
+from app.routers import widgets, news, twitter, reddit, co_mentions
 from app.utils.middleware import CorrelationIdMiddleware, RateLimitMiddleware
 from app.utils.errors import build_error_payload, map_status_to_code
 
@@ -80,6 +80,7 @@ app.include_router(widgets.router, prefix=settings.API_V1_STR)   # /widget/{type
 app.include_router(news.router, prefix=settings.API_V1_STR)      # /news/{entity_name}
 app.include_router(twitter.router, prefix=settings.API_V1_STR)   # Twitter (future)
 app.include_router(reddit.router, prefix=settings.API_V1_STR)    # Reddit (future)
+app.include_router(co_mentions.router, prefix=settings.API_V1_STR)  # Co-mentions
 
 
 @app.get("/health")
@@ -95,6 +96,7 @@ async def root_index():
         "endpoints": {
             "widget": "/api/v1/widget/{type}/{id}?sport=FOOTBALL|NBA|NFL",
             "news": "/api/v1/news/{entity_name}",
+            "co_mentions": "/api/v1/co-mentions/{type}/{id}?sport=FOOTBALL|NBA|NFL",
         },
         "docs": "/api/docs",
         "health": "/health",

--- a/backend/app/routers/co_mentions.py
+++ b/backend/app/routers/co_mentions.py
@@ -1,0 +1,93 @@
+"""
+Co-mentions Router - API endpoint for finding co-mentioned entities.
+
+GET /api/v1/co-mentions/{entity_type}/{entity_id}?sport=FOOTBALL&hours=48
+
+Returns entities from the same sport's database that appear alongside
+the searched entity in recent news articles, sorted by mention frequency.
+"""
+import logging
+from typing import Any, Dict
+
+from fastapi import APIRouter, Query, Response, Request, HTTPException
+
+from app.services import co_mentions_service
+from app.utils.http_cache import build_cache_control, compute_etag, if_none_match_matches
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/co-mentions", tags=["co-mentions"])
+
+# Cache policy (same as news - snappy updates)
+CO_MENTIONS_CACHE_CONTROL = build_cache_control(
+    max_age=60,
+    s_maxage=10 * 60,  # 10 minutes
+    stale_while_revalidate=60 * 60,
+    stale_if_error=60 * 60,
+)
+
+
+@router.get("/{entity_type}/{entity_id}")
+async def get_co_mentions(
+    request: Request,
+    response: Response,
+    entity_type: str,
+    entity_id: int,
+    sport: str = Query(..., description="Sport code: FOOTBALL, NBA, or NFL"),
+    hours: int = Query(48, description="Hours to look back for news"),
+) -> Dict[str, Any]:
+    """
+    Get entities co-mentioned with the given entity in recent news articles.
+
+    - Fetches news articles for the entity
+    - Cross-references with all entities in the sport's database
+    - Returns matches sorted by mention frequency
+
+    Args:
+        entity_type: "player" or "team"
+        entity_id: The entity's database ID
+        sport: Sport code (FOOTBALL, NBA, NFL)
+        hours: Hours to look back for news (default 48)
+
+    Returns:
+        List of co-mentioned entities with frequency counts
+    """
+    # Validate entity_type
+    if entity_type not in ("player", "team"):
+        raise HTTPException(status_code=400, detail="entity_type must be 'player' or 'team'")
+
+    # Validate sport
+    sport_upper = sport.upper()
+    if sport_upper not in ("FOOTBALL", "NBA", "NFL"):
+        raise HTTPException(status_code=400, detail="sport must be FOOTBALL, NBA, or NFL")
+
+    # Get HTTP client from app state
+    client = getattr(request.app.state, "http_client", None)
+    if client is None:
+        raise HTTPException(status_code=500, detail="HTTP client not initialized")
+
+    # Fetch co-mentions
+    co_mentions = await co_mentions_service.get_co_mentions(
+        client=client,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        sport=sport_upper,
+        hours=hours,
+    )
+
+    payload = {
+        "entity_type": entity_type,
+        "entity_id": entity_id,
+        "sport": sport_upper,
+        "hours": hours,
+        "count": len(co_mentions),
+        "co_mentions": co_mentions,
+    }
+
+    # ETag for conditional requests
+    etag = compute_etag(payload)
+    if if_none_match_matches(request.headers.get("if-none-match"), etag):
+        return Response(status_code=304, headers={"ETag": etag, "Cache-Control": CO_MENTIONS_CACHE_CONTROL})
+
+    response.headers["ETag"] = etag
+    response.headers["Cache-Control"] = CO_MENTIONS_CACHE_CONTROL
+    return payload

--- a/backend/app/services/co_mentions_service.py
+++ b/backend/app/services/co_mentions_service.py
@@ -1,0 +1,200 @@
+"""
+Co-mentions Service - Find entities mentioned alongside a searched entity.
+
+Cross-references articles fetched from news providers with entities in the
+local database to identify co-mentions. Returns entities sorted by frequency.
+"""
+import logging
+import re
+from typing import Any, Dict, List, Optional, Tuple
+from collections import Counter
+
+import httpx
+
+from app.database.local_dbs import (
+    list_all_players,
+    list_all_teams,
+    normalize_text,
+    get_player_by_id,
+    get_team_by_id,
+)
+from app.services.cache import basic_cache
+from app.services.singleflight import singleflight
+
+logger = logging.getLogger(__name__)
+
+# Cache TTL: 10 minutes (same as news)
+CO_MENTIONS_CACHE_TTL = 10 * 60
+
+
+def _build_entity_patterns(
+    players: List[Tuple[int, str]], teams: List[Tuple[int, str]]
+) -> Dict[str, Tuple[str, int, str]]:
+    """
+    Build a lookup dictionary for entity matching.
+
+    Returns a dict mapping normalized name -> (entity_type, entity_id, display_name)
+    """
+    patterns: Dict[str, Tuple[str, int, str]] = {}
+
+    for player_id, player_name in players:
+        if not player_name:
+            continue
+        norm = normalize_text(player_name)
+        if norm and len(norm) >= 3:  # Skip very short names to avoid false matches
+            patterns[norm] = ("player", player_id, player_name)
+
+    for team_id, team_name in teams:
+        if not team_name:
+            continue
+        norm = normalize_text(team_name)
+        if norm and len(norm) >= 3:
+            patterns[norm] = ("team", team_id, team_name)
+
+    return patterns
+
+
+def _find_mentions_in_text(
+    text: str,
+    entity_patterns: Dict[str, Tuple[str, int, str]],
+    exclude_entity_id: Optional[int] = None,
+    exclude_entity_type: Optional[str] = None,
+) -> List[Tuple[str, int, str]]:
+    """
+    Find all entity mentions in a text string.
+
+    Returns list of (entity_type, entity_id, display_name) for each match.
+    """
+    if not text:
+        return []
+
+    normalized_text = normalize_text(text)
+    found: List[Tuple[str, int, str]] = []
+
+    for norm_name, (entity_type, entity_id, display_name) in entity_patterns.items():
+        # Skip the entity being searched for
+        if exclude_entity_id is not None and exclude_entity_type is not None:
+            if entity_id == exclude_entity_id and entity_type == exclude_entity_type:
+                continue
+
+        # Check if the normalized name appears in the text
+        # Use word boundary matching to avoid partial matches
+        # For multi-word names, check if all words appear in sequence
+        words = norm_name.split()
+        if len(words) == 1:
+            # Single word: check with word boundaries
+            pattern = r'\b' + re.escape(norm_name) + r'\b'
+            if re.search(pattern, normalized_text):
+                found.append((entity_type, entity_id, display_name))
+        else:
+            # Multi-word: check if the phrase exists
+            if norm_name in normalized_text:
+                found.append((entity_type, entity_id, display_name))
+
+    return found
+
+
+async def get_co_mentions(
+    client: httpx.AsyncClient,
+    entity_type: str,
+    entity_id: int,
+    sport: str,
+    hours: int = 48,
+) -> List[Dict[str, Any]]:
+    """
+    Get entities co-mentioned with the given entity in recent news articles.
+
+    1. Fetches the entity's details to get its name
+    2. Fetches news articles for that entity
+    3. Scans articles for mentions of other entities in the same sport's database
+    4. Returns entities sorted by mention frequency
+
+    Args:
+        client: Async HTTP client for fetching news
+        entity_type: "player" or "team"
+        entity_id: The entity's database ID
+        sport: Sport code (e.g., "FOOTBALL", "NBA", "NFL")
+        hours: Hours to look back for news (default 48)
+
+    Returns:
+        List of co-mentioned entities with frequency counts
+    """
+    cache_key = f"co_mentions:{sport}:{entity_type}:{entity_id}:{hours}"
+    cached = basic_cache.get(cache_key)
+    if cached is not None:
+        logger.debug(f"Co-mentions cache HIT: {cache_key}")
+        return cached
+
+    async def _work() -> List[Dict[str, Any]]:
+        # Re-check cache after singleflight wait
+        cached2 = basic_cache.get(cache_key)
+        if cached2 is not None:
+            return cached2
+
+        # 1. Get the entity's name for article search
+        if entity_type == "player":
+            entity = get_player_by_id(sport, entity_id)
+            entity_name = entity.get("name") if entity else None
+        else:
+            entity = get_team_by_id(sport, entity_id)
+            entity_name = entity.get("name") if entity else None
+
+        if not entity_name:
+            logger.warning(f"Entity not found: {entity_type}/{entity_id} in {sport}")
+            return []
+
+        # 2. Fetch news articles for this entity
+        from app.routers.news import _fetch_news_async
+        articles = await _fetch_news_async(client, entity_name, hours=hours)
+
+        if not articles:
+            logger.info(f"No articles found for {entity_name}")
+            basic_cache.set(cache_key, [], ttl=CO_MENTIONS_CACHE_TTL)
+            return []
+
+        # 3. Load all entities from the sport's database
+        players = list_all_players(sport)
+        teams = list_all_teams(sport)
+
+        # Build pattern dictionary for matching
+        entity_patterns = _build_entity_patterns(players, teams)
+
+        # 4. Scan articles for entity mentions
+        mention_counter: Counter[Tuple[str, int, str]] = Counter()
+
+        for article in articles:
+            title = article.get("title", "")
+            # Combine title for scanning (could also include description if available)
+            text_to_scan = title
+
+            mentions = _find_mentions_in_text(
+                text_to_scan,
+                entity_patterns,
+                exclude_entity_id=entity_id,
+                exclude_entity_type=entity_type,
+            )
+
+            for mention in mentions:
+                mention_counter[mention] += 1
+
+        # 5. Build sorted results
+        results: List[Dict[str, Any]] = []
+        for (ent_type, ent_id, display_name), count in mention_counter.most_common():
+            results.append({
+                "entity_type": ent_type,
+                "entity_id": ent_id,
+                "name": display_name,
+                "mention_count": count,
+            })
+
+        # Cache results
+        basic_cache.set(cache_key, results, ttl=CO_MENTIONS_CACHE_TTL)
+        logger.info(f"Co-mentions cache SET: {cache_key} ({len(results)} entities)")
+
+        return results
+
+    try:
+        return await singleflight.do(cache_key, _work)
+    except Exception as e:
+        logger.error(f"Co-mentions error for {entity_type}/{entity_id}: {e}")
+        return []


### PR DESCRIPTION
- Create co_mentions_service.py: scans news articles for mentions of other
  entities in the same sport database, using normalized name matching
- Add co_mentions.py router: GET /api/v1/co-mentions/{type}/{id}?sport=X
  returns entities sorted by mention frequency with counts
- Update ContentCard.astro: lazy-load co-mentions on tab click, display
  entities with frequency badges linking to their mentions pages