### PR TITLE
feat: Display full names in entity widgets

### DIFF
--- a/astro-frontend/src/components/EntityWidget.astro
+++ b/astro-frontend/src/components/EntityWidget.astro
@@ -371,7 +371,7 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
         const playerData = data.player || {};
         const stats = data.statistics || [];
         const teamInfo = stats[0]?.team;
-        name = playerData.name || `${playerData.firstname || ''} ${playerData.lastname || ''}`.trim() || 'Unknown';
+        name = `${playerData.firstname || ''} ${playerData.lastname || ''}`.trim() || playerData.name || 'Unknown';
         logo = playerData.photo || '';
         subtitle = teamInfo?.name || '';
 

--- a/astro-frontend/src/components/EntityWidgetPair.astro
+++ b/astro-frontend/src/components/EntityWidgetPair.astro
@@ -310,7 +310,7 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
         const playerData = data.player || {};
         const stats = data.statistics || [];
         const teamInfo = stats[0]?.team;
-        name = playerData.name || `${playerData.firstname || ''} ${playerData.lastname || ''}`.trim() || 'Unknown';
+        name = `${playerData.firstname || ''} ${playerData.lastname || ''}`.trim() || playerData.name || 'Unknown';
         logo = playerData.photo || '';
         subtitle = teamInfo?.name || playerData.position || '';
       }

--- a/astro-frontend/src/components/SharedArticlesCard.astro
+++ b/astro-frontend/src/components/SharedArticlesCard.astro
@@ -302,7 +302,7 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
           return data.team?.name || null;
         } else {
           const player = data.player || {};
-          return player.name || `${player.firstname || ''} ${player.lastname || ''}`.trim() || null;
+          return `${player.firstname || ''} ${player.lastname || ''}`.trim() || player.name || null;
         }
       } catch {
         return null;


### PR DESCRIPTION
Updated entity widgets to prioritize firstname+lastname over the name field.
This ensures full names like "Cole Jermaine Palmer" are displayed instead of
abbreviated versions like "C. Palmer".

Changes:
- EntityWidget.astro: Prioritize firstname+lastname combination
- EntityWidgetPair.astro: Prioritize firstname+lastname combination
- SharedArticlesCard.astro: Prioritize firstname+lastname for search matching