### PR TITLE
feat: Improve news search accuracy with multi-query strategy

### DIFF
--- a/astro-frontend/src/components/ContentCard.astro
+++ b/astro-frontend/src/components/ContentCard.astro
@@ -354,6 +354,10 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
     private type: string | null = null;
     private id: string | null = null;
 
+    // Store entity info for news fetching
+    private entityName: string | null = null;
+    private entityTeam: string | null = null;
+
     // Store articles for co-mentions
     private articles: Article[] = [];
 
@@ -443,7 +447,20 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
           return;
         }
 
-        const newsUrl = `${this.apiUrl}/news/${encodeURIComponent(entityName)}`;
+        // Store entity info for later use
+        this.entityName = entityName;
+
+        // Extract team name for players (improves news search relevance)
+        if (this.type === 'player') {
+          this.entityTeam = widgetData.player?.currentTeam || widgetData.currentTeam || null;
+        }
+
+        // Build news URL with sport and team context for better search results
+        const newsParams = new URLSearchParams();
+        if (this.sport) newsParams.set('sport', this.sport.toUpperCase());
+        if (this.entityTeam) newsParams.set('team', this.entityTeam);
+
+        const newsUrl = `${this.apiUrl}/news/${encodeURIComponent(entityName)}?${newsParams.toString()}`;
         const newsRes = await fetch(newsUrl);
         if (!newsRes.ok) throw new Error(`News HTTP ${newsRes.status}`);
 

--- a/astro-frontend/src/components/SharedArticlesCard.astro
+++ b/astro-frontend/src/components/SharedArticlesCard.astro
@@ -234,9 +234,12 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
         return;
       }
 
-      // Fetch news for primary entity
+      // Fetch news for primary entity with sport context
       try {
-        const newsUrl = `${this.apiUrl}/news/${encodeURIComponent(primaryName)}`;
+        const newsParams = new URLSearchParams();
+        if (this.params.sport) newsParams.set('sport', this.params.sport.toUpperCase());
+
+        const newsUrl = `${this.apiUrl}/news/${encodeURIComponent(primaryName)}?${newsParams.toString()}`;
         const res = await fetch(newsUrl);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
 

--- a/astro-frontend/src/lib/types/index.ts
+++ b/astro-frontend/src/lib/types/index.ts
@@ -61,7 +61,11 @@ export interface NewsArticle {
 // News response from GET /api/v1/news/{entity_name}
 export interface NewsData {
   query: string;
+  sport?: string | null;
+  team?: string | null;
   hours: number;
+  hours_requested?: number;
+  extended?: boolean;
   count: number;
   articles: NewsArticle[];
 }

--- a/astro-frontend/src/lib/utils/co-mentions.ts
+++ b/astro-frontend/src/lib/utils/co-mentions.ts
@@ -337,14 +337,24 @@ export async function loadEntitiesForSport(sport: string): Promise<Entity[]> {
 
 /**
  * Fetch news articles for an entity.
+ *
+ * Enhanced with sport/team context for better search relevance.
+ * The backend will use these to build smarter queries and may
+ * auto-extend the time range if few results are found.
  */
 export async function fetchArticles(
   entityName: string,
   apiUrl: string,
-  hours: number = 48
+  hours: number = 48,
+  sport?: string,
+  team?: string
 ): Promise<Article[]> {
+  const params = new URLSearchParams({ hours: hours.toString() });
+  if (sport) params.set('sport', sport);
+  if (team) params.set('team', team);
+
   const response = await fetch(
-    `${apiUrl}/news/${encodeURIComponent(entityName)}?hours=${hours}`
+    `${apiUrl}/news/${encodeURIComponent(entityName)}?${params.toString()}`
   );
 
   if (!response.ok) {
@@ -364,6 +374,7 @@ export async function fetchArticles(
  * @param sport - Sport code (FOOTBALL, NBA, NFL)
  * @param apiUrl - Base API URL
  * @param hours - Hours to look back for news
+ * @param team - Team name for player context (improves search relevance)
  * @returns List of co-mentioned entities with counts
  */
 export async function getCoMentions(
@@ -372,11 +383,12 @@ export async function getCoMentions(
   entityType: 'player' | 'team',
   sport: string,
   apiUrl: string,
-  hours: number = 48
+  hours: number = 48,
+  team?: string
 ): Promise<CoMention[]> {
   // Fetch articles and entities in parallel
   const [articles, entities] = await Promise.all([
-    fetchArticles(entityName, apiUrl, hours),
+    fetchArticles(entityName, apiUrl, hours, sport, team),
     loadEntitiesForSport(sport),
   ]);
 

--- a/backend/app/routers/news.py
+++ b/backend/app/routers/news.py
@@ -1,13 +1,15 @@
 """
-News Router - Simple news/mentions endpoint.
+News Router - Enhanced news/mentions endpoint with multi-query strategy.
 
-GET /api/v1/news/{entity_name}?hours=48
+GET /api/v1/news/{entity_name}?hours=48&sport=NFL&team=Chiefs
 
-Fetches news from Google News RSS. Cached for 10 minutes.
+Fetches news from Google News RSS using multiple query strategies for better coverage.
+Cached for 10 minutes. Adaptive time range extends up to 1 week if < 3 hits.
 """
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Set
 from datetime import datetime, timedelta, timezone
+from urllib.parse import quote_plus
 
 from fastapi import APIRouter, Query, Response, Request, HTTPException
 import httpx
@@ -33,6 +35,270 @@ NEWS_CACHE_CONTROL = build_cache_control(
     stale_if_error=60 * 60,
 )
 
+# Minimum articles threshold - if below this, extend time range
+MIN_ARTICLES_THRESHOLD = 3
+
+# Maximum articles to return
+MAX_ARTICLES = 50
+
+# Time range escalation (in hours): 48h -> 96h -> 168h (1 week)
+TIME_RANGE_ESCALATION = [48, 96, 168]
+
+# Sport display names for query enhancement
+SPORT_KEYWORDS = {
+    "NFL": ["NFL", "football"],
+    "NBA": ["NBA", "basketball"],
+    "FOOTBALL": ["soccer", "football"],
+}
+
+
+def _build_query_variations(
+    entity_name: str,
+    sport: Optional[str] = None,
+    team: Optional[str] = None,
+) -> List[str]:
+    """
+    Build multiple query variations for better news coverage.
+
+    Query strategies:
+    1. Full name (baseline)
+    2. "Full name" in quotes (exact phrase)
+    3. Full name + sport keyword
+    4. Last name + team (if available)
+    5. Full name + team (if available)
+
+    Returns list of query strings ordered by specificity.
+    """
+    queries = []
+    name_parts = entity_name.strip().split()
+
+    # 1. Quoted full name (exact phrase match - highest precision)
+    queries.append(f'"{entity_name}"')
+
+    # 2. Full name + sport keyword (if sport provided)
+    if sport and sport.upper() in SPORT_KEYWORDS:
+        keywords = SPORT_KEYWORDS[sport.upper()]
+        # Use primary keyword
+        queries.append(f"{entity_name} {keywords[0]}")
+
+    # 3. Full name + team (if available)
+    if team:
+        queries.append(f"{entity_name} {team}")
+
+    # 4. Last name + team (for players with team context)
+    if team and len(name_parts) >= 2:
+        last_name = name_parts[-1]
+        # Only use if last name is substantial (4+ chars)
+        if len(last_name) >= 4:
+            queries.append(f"{last_name} {team}")
+
+    # 5. Plain full name (broadest search - catches everything)
+    queries.append(entity_name)
+
+    return queries
+
+
+async def _fetch_single_query(
+    client: httpx.AsyncClient,
+    query: str,
+    hours: int,
+) -> List[Dict[str, Any]]:
+    """
+    Fetch news for a single query string.
+
+    Returns raw articles without deduplication (caller handles that).
+    """
+    import feedparser
+    import time
+
+    # URL-encode the query
+    encoded_query = quote_plus(query)
+    rss_url = f"https://news.google.com/rss/search?q={encoded_query}"
+
+    try:
+        resp = await client.get(rss_url, timeout=10.0)
+        resp.raise_for_status()
+    except httpx.HTTPError as e:
+        logger.warning(f"Query failed '{query}': {e}")
+        return []
+
+    feed = feedparser.parse(resp.text)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
+    articles = []
+
+    for entry in getattr(feed, "entries", []) or []:
+        pub_date = None
+        try:
+            if getattr(entry, "published_parsed", None):
+                dt = datetime.fromtimestamp(
+                    time.mktime(entry.published_parsed)
+                ).replace(tzinfo=timezone.utc)
+                if dt < cutoff:
+                    continue
+                pub_date = dt.isoformat()
+        except Exception:
+            pass
+
+        # Extract source
+        source = ""
+        if hasattr(entry, "source") and isinstance(entry.source, dict):
+            source = entry.source.get("title", "")
+
+        articles.append({
+            "title": getattr(entry, "title", "") or "",
+            "link": getattr(entry, "link", "") or "",
+            "pub_date": pub_date,
+            "source": source,
+        })
+
+    return articles
+
+
+def _deduplicate_articles(articles: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Deduplicate articles by link URL.
+
+    Preserves order (first occurrence wins).
+    """
+    seen_links: Set[str] = set()
+    unique = []
+
+    for article in articles:
+        link = article.get("link", "")
+        if link and link not in seen_links:
+            seen_links.add(link)
+            unique.append(article)
+
+    return unique
+
+
+def _sort_articles_by_date(articles: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Sort articles by publication date (newest first).
+
+    Articles without dates go to the end.
+    """
+    def sort_key(article: Dict[str, Any]) -> str:
+        # ISO format sorts correctly as strings
+        return article.get("pub_date") or "0000-00-00"
+
+    return sorted(articles, key=sort_key, reverse=True)
+
+
+async def _fetch_news_multi_query(
+    client: httpx.AsyncClient,
+    entity_name: str,
+    hours: int,
+    sport: Optional[str] = None,
+    team: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Fetch news using multiple query strategies and merge results.
+
+    Executes queries in parallel for speed, deduplicates by link,
+    and sorts by date.
+    """
+    queries = _build_query_variations(entity_name, sport, team)
+    logger.debug(f"Multi-query for '{entity_name}': {queries}")
+
+    # Fetch all queries in parallel
+    import asyncio
+    tasks = [_fetch_single_query(client, q, hours) for q in queries]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    # Merge all results
+    all_articles = []
+    for i, result in enumerate(results):
+        if isinstance(result, Exception):
+            logger.warning(f"Query {i} failed: {result}")
+            continue
+        all_articles.extend(result)
+
+    # Deduplicate and sort
+    unique = _deduplicate_articles(all_articles)
+    sorted_articles = _sort_articles_by_date(unique)
+
+    return sorted_articles[:MAX_ARTICLES]
+
+
+async def _fetch_news_async(
+    client: httpx.AsyncClient,
+    entity_name: str,
+    hours: int = 48,
+    sport: Optional[str] = None,
+    team: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Fetch news articles with multi-query strategy and adaptive time range.
+
+    If fewer than MIN_ARTICLES_THRESHOLD articles are found, automatically
+    extends the time range up to 1 week maximum.
+
+    Returns dict with articles and metadata about the search.
+    """
+    # Build cache key including all parameters
+    cache_key = f"news:v2:{entity_name.lower()}:{hours}:{(sport or '').lower()}:{(team or '').lower()}"
+    cached = widget_cache.get(cache_key)
+    if cached is not None:
+        logger.debug(f"News cache HIT: {cache_key}")
+        return cached
+
+    async def _work() -> Dict[str, Any]:
+        # Re-check cache after waiting
+        cached2 = widget_cache.get(cache_key)
+        if cached2 is not None:
+            return cached2
+
+        final_hours = hours
+        articles = []
+
+        # Try escalating time ranges if not enough results
+        for try_hours in TIME_RANGE_ESCALATION:
+            if try_hours < hours:
+                continue  # Skip if requested hours is already higher
+
+            articles = await _fetch_news_multi_query(
+                client, entity_name, try_hours, sport, team
+            )
+
+            final_hours = try_hours
+
+            # If we have enough articles, stop escalating
+            if len(articles) >= MIN_ARTICLES_THRESHOLD:
+                break
+
+            logger.info(
+                f"Only {len(articles)} articles for '{entity_name}' with {try_hours}h, "
+                f"extending time range..."
+            )
+
+        result = {
+            "articles": articles,
+            "hours_used": final_hours,
+            "hours_requested": hours,
+            "extended": final_hours > hours,
+        }
+
+        widget_cache.set(cache_key, result, ttl=NEWS_CACHE_TTL)
+        logger.info(
+            f"News cache SET: {cache_key} ({len(articles)} articles, "
+            f"hours={final_hours}, extended={result['extended']})"
+        )
+        return result
+
+    try:
+        return await singleflight.do(cache_key, _work)
+    except httpx.HTTPStatusError as e:
+        status = e.response.status_code if e.response is not None else None
+        logger.error(f"News upstream status error for '{entity_name}' status={status}")
+        raise HTTPException(status_code=502, detail="News upstream error")
+    except httpx.HTTPError as e:
+        logger.error(f"News network error for '{entity_name}': {e}")
+        raise HTTPException(status_code=502, detail="News network error")
+    except Exception as e:
+        logger.error(f"News fetch failed for '{entity_name}': {e}")
+        return {"articles": [], "hours_used": hours, "hours_requested": hours, "extended": False}
+
 
 def _fetch_news(query: str, hours: int = 48) -> List[Dict[str, Any]]:
     """Deprecated sync fetch.
@@ -43,101 +309,46 @@ def _fetch_news(query: str, hours: int = 48) -> List[Dict[str, Any]]:
     return []
 
 
-async def _fetch_news_async(client: httpx.AsyncClient, query: str, hours: int = 48) -> List[Dict[str, Any]]:
-    """Fetch news articles from Google News RSS with caching.
-
-    Network fetch uses the shared httpx client for better connection reuse.
-    Parsing is local via feedparser.
-    """
-    cache_key = f"news:{query.lower()}:{hours}"
-    cached = widget_cache.get(cache_key)
-    if cached is not None:
-        logger.debug(f"News cache HIT: {cache_key}")
-        return cached
-
-    async def _work() -> List[Dict[str, Any]]:
-        # Re-check cache after waiting (another caller may have filled it)
-        cached2 = widget_cache.get(cache_key)
-        if cached2 is not None:
-            return cached2
-
-        import feedparser
-        import time
-
-        rss_url = f"https://news.google.com/rss/search?q={query.replace(' ', '+')}"
-        resp = await client.get(rss_url)
-        resp.raise_for_status()
-        feed = feedparser.parse(resp.text)
-
-        cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
-        articles = []
-
-        for entry in getattr(feed, "entries", []) or []:
-            # Filter by date
-            pub_date = None
-            try:
-                if getattr(entry, "published_parsed", None):
-                    dt = datetime.fromtimestamp(time.mktime(entry.published_parsed)).replace(tzinfo=timezone.utc)
-                    if dt < cutoff:
-                        continue
-                    pub_date = dt.isoformat()
-            except Exception:
-                pass
-
-            # Extract source
-            source = ""
-            if hasattr(entry, "source") and isinstance(entry.source, dict):
-                source = entry.source.get("title", "")
-
-            articles.append({
-                "title": getattr(entry, "title", "") or "",
-                "link": getattr(entry, "link", "") or "",
-                "pub_date": pub_date,
-                "source": source,
-            })
-
-        result = articles[:20]  # Limit to 20 articles
-        widget_cache.set(cache_key, result, ttl=NEWS_CACHE_TTL)
-        logger.info(f"News cache SET: {cache_key} ({len(result)} articles)")
-        return result
-
-    try:
-        return await singleflight.do(cache_key, _work)
-    except httpx.HTTPStatusError as e:
-        status = e.response.status_code if e.response is not None else None
-        logger.error(f"News upstream status error for '{query}' status={status}")
-        raise HTTPException(status_code=502, detail="News upstream error")
-    except httpx.HTTPError as e:
-        logger.error(f"News network error for '{query}': {e}")
-        raise HTTPException(status_code=502, detail="News network error")
-    except Exception as e:
-        logger.error(f"News parse failed for '{query}': {e}")
-        return []
-
-
 @router.get("/{entity_name}")
 async def get_news(
     request: Request,
     response: Response,
     entity_name: str,
-    hours: int = Query(48, description="Hours to look back for news"),
+    hours: int = Query(48, description="Hours to look back for news (may auto-extend if few results)"),
+    sport: Optional[str] = Query(None, description="Sport context (NFL, NBA, FOOTBALL) for better search relevance"),
+    team: Optional[str] = Query(None, description="Team name for player context"),
 ) -> Dict[str, Any]:
     """
-    Get news articles for an entity.
-    
-    - Fetches from Google News RSS
+    Get news articles for an entity with enhanced multi-query search.
+
+    Features:
+    - Multiple query strategies for better coverage
+    - Sport/team context for relevance filtering
+    - Adaptive time range: auto-extends up to 1 week if < 3 results
+    - Returns up to 50 deduplicated articles sorted by date
     - Cached for 10 minutes
-    - Returns up to 20 articles from the last N hours
     """
     client = getattr(request.app.state, "http_client", None)
     if client is None:
         raise HTTPException(status_code=500, detail="HTTP client not initialized")
 
-    articles = await _fetch_news_async(client, entity_name, hours=hours)
+    result = await _fetch_news_async(
+        client,
+        entity_name,
+        hours=hours,
+        sport=sport,
+        team=team,
+    )
+
+    articles = result.get("articles", [])
 
     payload = {
         "query": entity_name,
-        "hours": hours,
+        "sport": sport,
+        "team": team,
+        "hours": result.get("hours_used", hours),
+        "hours_requested": result.get("hours_requested", hours),
+        "extended": result.get("extended", False),
         "count": len(articles),
         "articles": articles,
     }


### PR DESCRIPTION
- Add sport and team parameters to news API for context-aware searching
- Implement multiple query strategies (quoted name, name+sport, name+team)
- Add adaptive time range: auto-extends from 48h to 1 week if < 3 results
- Increase article limit from 20 to 50 for more co-mention opportunities
- Execute queries in parallel and deduplicate results by URL
- Update frontend to pass sport/team context when fetching news
- Update NewsData type to include new response fields