### PR TITLE
feat: Add entity comparison feature for side-by-side stats analysis

### DIFF
--- a/astro-frontend/src/components/ComparisonSearchModal.astro
+++ b/astro-frontend/src/components/ComparisonSearchModal.astro
@@ -1,0 +1,401 @@
+---
+/**
+ * Comparison Search Modal
+ *
+ * A modal overlay with a search box for selecting an entity to compare.
+ * Uses the AutocompleteManager for entity search functionality.
+ * Filters results to match the current entity type (team/player) and sport.
+ */
+---
+
+<div id="comparison-modal" class="comparison-modal hidden">
+  <div class="modal-backdrop"></div>
+  <div class="modal-content card">
+    <div class="modal-header">
+      <h3 class="modal-title">Add Comparison</h3>
+      <button type="button" class="modal-close" aria-label="Close">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M18 6L6 18M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+    <div class="modal-body">
+      <div class="search-container">
+        <input
+          type="text"
+          id="comparison-search-input"
+          class="search-input input"
+          placeholder="Search..."
+          autocomplete="off"
+        />
+        <div id="comparison-suggestions" class="suggestions-dropdown hidden"></div>
+      </div>
+      <p class="search-hint">
+        <span id="comparison-hint-text">Search for a similar entity to compare</span>
+      </p>
+    </div>
+  </div>
+</div>
+
+<style>
+  .comparison-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 10vh;
+  }
+
+  .comparison-modal.hidden {
+    display: none;
+  }
+
+  .modal-backdrop {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.4);
+  }
+
+  :global(.dark) .modal-backdrop {
+    background-color: rgba(0, 0, 0, 0.6);
+  }
+
+  .modal-content {
+    position: relative;
+    width: 100%;
+    max-width: 400px;
+    margin: 0 1rem;
+    animation: modalSlideIn 0.2s ease-out;
+  }
+
+  @keyframes modalSlideIn {
+    from {
+      opacity: 0;
+      transform: translateY(-10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  :global(.dark) .modal-header {
+    border-bottom-color: var(--border-dark);
+  }
+
+  .modal-title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text);
+  }
+
+  :global(.dark) .modal-title {
+    color: var(--text-dark);
+  }
+
+  .modal-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--text-secondary);
+    border-radius: 4px;
+  }
+
+  .modal-close:hover {
+    background-color: var(--border);
+  }
+
+  :global(.dark) .modal-close {
+    color: var(--text-secondary-dark);
+  }
+
+  :global(.dark) .modal-close:hover {
+    background-color: var(--border-dark);
+  }
+
+  .modal-body {
+    padding: 1.25rem;
+  }
+
+  .search-container {
+    position: relative;
+  }
+
+  .search-input {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+  }
+
+  .suggestions-dropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    max-height: 250px;
+    overflow-y: auto;
+    background-color: var(--bg-card);
+    border: 1px solid var(--border);
+    border-top: none;
+    border-radius: 0 0 0.25rem 0.25rem;
+    z-index: 10;
+  }
+
+  :global(.dark) .suggestions-dropdown {
+    background-color: var(--bg-card-dark);
+    border-color: var(--border-dark);
+  }
+
+  .suggestions-dropdown.hidden {
+    display: none;
+  }
+
+  .search-hint {
+    margin: 0.75rem 0 0;
+    font-size: 0.8rem;
+    color: var(--text-tertiary);
+  }
+
+  :global(.dark) .search-hint {
+    color: var(--text-tertiary-dark);
+  }
+
+  /* Suggestion item styles */
+  :global(.comparison-suggestion-item) {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    text-align: left;
+    background: none;
+    border: none;
+    border-bottom: 1px solid var(--border);
+    cursor: pointer;
+  }
+
+  :global(.comparison-suggestion-item:last-child) {
+    border-bottom: none;
+  }
+
+  :global(.comparison-suggestion-item:hover),
+  :global(.comparison-suggestion-item.selected) {
+    background-color: var(--border);
+  }
+
+  :global(.dark .comparison-suggestion-item) {
+    border-bottom-color: var(--border-dark);
+  }
+
+  :global(.dark .comparison-suggestion-item:hover),
+  :global(.dark .comparison-suggestion-item.selected) {
+    background-color: var(--border-dark);
+  }
+
+  :global(.comparison-suggestion-name) {
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--text);
+  }
+
+  :global(.dark .comparison-suggestion-name) {
+    color: var(--text-dark);
+  }
+
+  :global(.comparison-suggestion-meta) {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+  }
+
+  :global(.dark .comparison-suggestion-meta) {
+    color: var(--text-secondary-dark);
+  }
+
+  :global(.no-results) {
+    padding: 1rem;
+    text-align: center;
+    font-size: 0.85rem;
+    color: var(--text-tertiary);
+  }
+
+  :global(.dark .no-results) {
+    color: var(--text-tertiary-dark);
+  }
+
+  @media (max-width: 480px) {
+    .comparison-modal {
+      padding-top: 5vh;
+    }
+
+    .modal-content {
+      margin: 0 0.5rem;
+    }
+  }
+</style>
+
+<script>
+  import { AutocompleteManager, type AutocompleteEntity } from '../lib/utils/autocomplete';
+  import { escapeHtml } from '../lib/utils/dom';
+
+  /**
+   * ComparisonModalManager
+   *
+   * Manages the comparison search modal, including opening/closing,
+   * entity search, and selection.
+   */
+  class ComparisonModalManager {
+    private modal: HTMLElement | null = null;
+    private backdrop: HTMLElement | null = null;
+    private closeBtn: HTMLElement | null = null;
+    private inputEl: HTMLInputElement | null = null;
+    private suggestionsEl: HTMLElement | null = null;
+    private hintEl: HTMLElement | null = null;
+
+    private autocomplete: AutocompleteManager | null = null;
+    private currentSport: string = '';
+    private currentType: string = '';
+    private currentId: string = '';
+    private onSelectCallback: ((entity: AutocompleteEntity) => void) | null = null;
+
+    constructor() {
+      this.modal = document.getElementById('comparison-modal');
+      this.backdrop = this.modal?.querySelector('.modal-backdrop') || null;
+      this.closeBtn = this.modal?.querySelector('.modal-close') || null;
+      this.inputEl = document.getElementById('comparison-search-input') as HTMLInputElement;
+      this.suggestionsEl = document.getElementById('comparison-suggestions');
+      this.hintEl = document.getElementById('comparison-hint-text');
+
+      this.bindEvents();
+      this.exposeAPI();
+    }
+
+    private bindEvents() {
+      // Close on backdrop click
+      this.backdrop?.addEventListener('click', () => this.close());
+
+      // Close on close button click
+      this.closeBtn?.addEventListener('click', () => this.close());
+
+      // Close on Escape key
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && this.isOpen()) {
+          this.close();
+        }
+      });
+    }
+
+    private exposeAPI() {
+      // Expose open/close methods globally for other components
+      (window as any).comparisonModal = {
+        open: (sport: string, type: string, id: string, onSelect: (entity: AutocompleteEntity) => void) => {
+          this.open(sport, type, id, onSelect);
+        },
+        close: () => this.close(),
+        isOpen: () => this.isOpen(),
+      };
+    }
+
+    public open(sport: string, type: string, id: string, onSelect: (entity: AutocompleteEntity) => void) {
+      if (!this.modal || !this.inputEl || !this.suggestionsEl) return;
+
+      this.currentSport = sport.toLowerCase();
+      this.currentType = type;
+      this.currentId = id;
+      this.onSelectCallback = onSelect;
+
+      // Update hint text
+      const typeDisplay = type === 'team' ? 'team' : 'player';
+      if (this.hintEl) {
+        this.hintEl.textContent = `Search for another ${typeDisplay} to compare`;
+      }
+
+      // Initialize autocomplete if needed
+      if (!this.autocomplete) {
+        this.autocomplete = new AutocompleteManager({
+          inputEl: this.inputEl,
+          suggestionsEl: this.suggestionsEl,
+          initialSport: this.currentSport,
+          itemClass: 'comparison-suggestion-item',
+          renderItem: (entity, index) => `
+            <button
+              type="button"
+              data-index="${index}"
+              class="comparison-suggestion-item"
+              tabindex="-1"
+            >
+              <div class="comparison-suggestion-name">${escapeHtml(entity.name)}</div>
+              <div class="comparison-suggestion-meta">${entity.type === 'player' ? (entity.team || 'Player') : 'Team'}</div>
+            </button>
+          `,
+          onSelect: (entity) => {
+            // Filter: must be same type and not the same entity
+            if (entity.type !== this.currentType) {
+              return; // Should not happen due to filtering, but safety check
+            }
+            if (entity.id === this.currentId) {
+              // Can't compare with self
+              return;
+            }
+            this.close();
+            if (this.onSelectCallback) {
+              this.onSelectCallback(entity);
+            }
+          },
+        });
+      } else {
+        // Update sport if changed
+        this.autocomplete.setSport(this.currentSport);
+      }
+
+      // Clear input
+      this.inputEl.value = '';
+
+      // Show modal
+      this.modal.classList.remove('hidden');
+      document.body.style.overflow = 'hidden';
+
+      // Focus input
+      setTimeout(() => {
+        this.inputEl?.focus();
+      }, 100);
+    }
+
+    public close() {
+      if (!this.modal) return;
+
+      this.modal.classList.add('hidden');
+      document.body.style.overflow = '';
+      this.onSelectCallback = null;
+    }
+
+    public isOpen(): boolean {
+      return this.modal ? !this.modal.classList.contains('hidden') : false;
+    }
+  }
+
+  // Initialize on page load
+  new ComparisonModalManager();
+</script>

--- a/astro-frontend/src/components/EntityWidget.astro
+++ b/astro-frontend/src/components/EntityWidget.astro
@@ -1,26 +1,28 @@
 ---
 /**
  * Entity Widget Island
- * 
+ *
  * Lightweight component hydrated by backend JSON.
  * Fetches: GET /api/v1/entity/{type}/{id}?sport={sport}&include=widget
  */
 
 interface Props {
   page?: 'mentions' | 'entity';
+  showCompareButton?: boolean;
 }
 
-const { page = 'mentions' } = Astro.props;
+const { page = 'mentions', showCompareButton = false } = Astro.props;
 const buttonText = page === 'mentions' ? 'Statistical Profile' : 'Recent Mentions';
 const buttonDest = page === 'mentions' ? 'entity' : 'mentions';
 const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
 ---
 
-<div 
-  id="entity-widget" 
+<div
+  id="entity-widget"
   class="entity-widget card"
   data-api={apiUrl}
   data-dest={buttonDest}
+  data-show-compare={showCompareButton ? 'true' : 'false'}
 >
   <div class="ew-body">
     <!-- Loading -->
@@ -44,6 +46,19 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
     </div>
   </div>
 
+  <!-- Compare Button (+ icon) -->
+  <button
+    id="ew-compare-btn"
+    class="ew-compare-btn hidden"
+    type="button"
+    title="Compare with another entity"
+    aria-label="Add comparison"
+  >
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M12 5v14M5 12h14" />
+    </svg>
+  </button>
+
   <!-- Button -->
   <a id="ew-button" href="#" class="ew-button">{buttonText}</a>
 </div>
@@ -59,6 +74,46 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
     align-items: center;
     border-radius: 0.375rem;
     overflow: hidden;
+    position: relative;
+  }
+
+  .ew-compare-btn {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    background-color: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 50%;
+    cursor: pointer;
+    color: var(--text-tertiary);
+    transition: color 0.15s, border-color 0.15s;
+    z-index: 5;
+  }
+
+  .ew-compare-btn:hover {
+    color: var(--text-secondary);
+    border-color: var(--text-tertiary);
+  }
+
+  .ew-compare-btn.hidden {
+    display: none;
+  }
+
+  :global(.dark) .ew-compare-btn {
+    background-color: var(--bg-dark);
+    border-color: var(--border-dark);
+    color: var(--text-tertiary-dark);
+  }
+
+  :global(.dark) .ew-compare-btn:hover {
+    color: var(--text-secondary-dark);
+    border-color: var(--text-tertiary-dark);
   }
 
   .ew-body {
@@ -272,6 +327,7 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
     private widget: HTMLElement | null = null;
     private apiUrl = '';
     private buttonDest = '';
+    private showCompare = false;
     private sport: string | null = null;
     private type: string | null = null;
     private id: string | null = null;
@@ -284,6 +340,9 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
     private detailsEl: HTMLElement | null = null;
     private logoEl: HTMLImageElement | null = null;
     private buttonEl: HTMLAnchorElement | null = null;
+    private compareBtnEl: HTMLButtonElement | null = null;
+
+    private entityName: string = '';
 
     constructor() {
       const widget = document.getElementById('entity-widget');
@@ -292,6 +351,7 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
       this.widget = widget;
       this.apiUrl = widget.dataset.api || 'http://localhost:8000/api/v1';
       this.buttonDest = widget.dataset.dest || 'mentions';
+      this.showCompare = widget.dataset.showCompare === 'true';
 
       const params = parseEntityParams();
       this.sport = params.sport;
@@ -306,13 +366,22 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
       this.detailsEl = document.getElementById('ew-details');
       this.logoEl = document.getElementById('ew-logo') as HTMLImageElement;
       this.buttonEl = document.getElementById('ew-button') as HTMLAnchorElement;
+      this.compareBtnEl = document.getElementById('ew-compare-btn') as HTMLButtonElement;
 
       this.init();
+      this.exposeAPI();
     }
 
     private init() {
       if (this.sport && this.type && this.id && this.buttonEl) {
         this.buttonEl.href = `/${this.buttonDest}?sport=${this.sport}&type=${this.type}&id=${this.id}`;
+      }
+
+      // Setup compare button click handler
+      if (this.compareBtnEl) {
+        this.compareBtnEl.addEventListener('click', () => {
+          this.onCompareClick();
+        });
       }
 
       if (!this.sport || !this.type || !this.id) {
@@ -321,6 +390,30 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
       }
 
       this.fetchData();
+    }
+
+    private exposeAPI() {
+      // Expose widget API for other components
+      (window as any).entityWidget = {
+        getSport: () => this.sport,
+        getType: () => this.type,
+        getId: () => this.id,
+        getName: () => this.entityName,
+        hide: () => this.hide(),
+        show: () => this.showWidget(),
+      };
+    }
+
+    private onCompareClick() {
+      // Dispatch event with entity info for the comparison modal
+      window.dispatchEvent(new CustomEvent('comparison:add', {
+        detail: {
+          sport: this.sport,
+          type: this.type,
+          id: this.id,
+          name: this.entityName,
+        },
+      }));
     }
 
     private async fetchData() {
@@ -402,6 +495,9 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
         }
       }
 
+      // Store entity name for API
+      this.entityName = name;
+
       if (this.nameEl) this.nameEl.textContent = name;
       if (this.subtitleEl) this.subtitleEl.textContent = subtitle;
 
@@ -422,6 +518,11 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
       }
 
       this.showContent();
+
+      // Show compare button if enabled
+      if (this.showCompare && this.compareBtnEl) {
+        this.compareBtnEl.classList.remove('hidden');
+      }
     }
 
     private showContent() {
@@ -434,6 +535,14 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
       if (this.loadingEl) this.loadingEl.style.display = 'none';
       if (this.contentEl) this.contentEl.style.display = 'none';
       if (this.errorEl) this.errorEl.style.display = 'flex';
+    }
+
+    private hide() {
+      if (this.widget) this.widget.classList.add('hidden');
+    }
+
+    private showWidget() {
+      if (this.widget) this.widget.classList.remove('hidden');
     }
   }
 

--- a/astro-frontend/src/components/EntityWidgetComparison.astro
+++ b/astro-frontend/src/components/EntityWidgetComparison.astro
@@ -1,0 +1,554 @@
+---
+/**
+ * Entity Widget Comparison
+ *
+ * Displays two entity widgets side-by-side for comparison.
+ * Used on the entity page when a comparison entity is selected.
+ * Shows colored indicators and a legend for differentiation.
+ */
+
+const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
+---
+
+<div id="entity-widget-comparison" class="entity-comparison-container hidden">
+  <!-- Legend -->
+  <div class="comparison-legend">
+    <div class="legend-item">
+      <span class="legend-dot primary"></span>
+      <span id="legend-primary-name" class="legend-name">Primary</span>
+    </div>
+    <div class="legend-item">
+      <span class="legend-dot secondary"></span>
+      <span id="legend-secondary-name" class="legend-name">Comparison</span>
+    </div>
+  </div>
+
+  <!-- Entity Widgets Container -->
+  <div class="entity-pair-wrapper">
+    <!-- Primary Entity -->
+    <div
+      id="compare-primary-widget"
+      class="entity-widget-half card"
+      data-api={apiUrl}
+      data-entity="primary"
+    >
+      <div class="color-indicator primary"></div>
+      <div class="ew-body">
+        <div id="compare-primary-loading" class="ew-loading">
+          <div class="skeleton-circle"></div>
+          <div class="skeleton-line"></div>
+          <div class="skeleton-line short"></div>
+        </div>
+        <div id="compare-primary-content" class="ew-content">
+          <img id="compare-primary-logo" class="ew-logo" src="" alt="" style="display: none;" />
+          <h2 id="compare-primary-name" class="ew-name"></h2>
+          <p id="compare-primary-subtitle" class="ew-subtitle"></p>
+        </div>
+        <div id="compare-primary-error" class="ew-error">
+          <p>Unable to load entity</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Secondary (Comparison) Entity -->
+    <div
+      id="compare-secondary-widget"
+      class="entity-widget-half card"
+      data-api={apiUrl}
+      data-entity="secondary"
+    >
+      <div class="color-indicator secondary"></div>
+      <div class="ew-body">
+        <div id="compare-secondary-loading" class="ew-loading">
+          <div class="skeleton-circle"></div>
+          <div class="skeleton-line"></div>
+          <div class="skeleton-line short"></div>
+        </div>
+        <div id="compare-secondary-content" class="ew-content">
+          <img id="compare-secondary-logo" class="ew-logo" src="" alt="" style="display: none;" />
+          <h2 id="compare-secondary-name" class="ew-name"></h2>
+          <p id="compare-secondary-subtitle" class="ew-subtitle"></p>
+        </div>
+        <div id="compare-secondary-error" class="ew-error">
+          <p>Unable to load entity</p>
+        </div>
+      </div>
+      <!-- Remove comparison button -->
+      <button id="remove-comparison-btn" class="remove-comparison-btn" title="Remove comparison">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M18 6L6 18M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .entity-comparison-container {
+    width: 100%;
+    max-width: 600px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .entity-comparison-container.hidden {
+    display: none;
+  }
+
+  .comparison-legend {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+    padding: 0.5rem 0;
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .legend-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+  }
+
+  .legend-dot.primary {
+    background-color: var(--compare-primary);
+  }
+
+  .legend-dot.secondary {
+    background-color: var(--compare-secondary);
+  }
+
+  :global(.dark) .legend-dot.primary {
+    background-color: var(--compare-primary-dark);
+  }
+
+  :global(.dark) .legend-dot.secondary {
+    background-color: var(--compare-secondary-dark);
+  }
+
+  .legend-name {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    max-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  :global(.dark) .legend-name {
+    color: var(--text-secondary-dark);
+  }
+
+  .entity-pair-wrapper {
+    display: flex;
+    gap: 1rem;
+    width: 100%;
+  }
+
+  .entity-widget-half {
+    flex: 1;
+    text-align: center;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    border-radius: 0.375rem;
+    overflow: hidden;
+    min-width: 0;
+    position: relative;
+  }
+
+  .color-indicator {
+    width: 100%;
+    height: 4px;
+  }
+
+  .color-indicator.primary {
+    background-color: var(--compare-primary);
+  }
+
+  .color-indicator.secondary {
+    background-color: var(--compare-secondary);
+  }
+
+  :global(.dark) .color-indicator.primary {
+    background-color: var(--compare-primary-dark);
+  }
+
+  :global(.dark) .color-indicator.secondary {
+    background-color: var(--compare-secondary-dark);
+  }
+
+  .ew-body {
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    width: 100%;
+    flex: 1;
+    min-height: 120px;
+  }
+
+  .ew-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .ew-content, .ew-error {
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .skeleton-circle {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: var(--border);
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+
+  .skeleton-line {
+    height: 12px;
+    width: 100px;
+    border-radius: 4px;
+    background: var(--border);
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+
+  .skeleton-line.short {
+    width: 70px;
+  }
+
+  :global(.dark) .skeleton-circle,
+  :global(.dark) .skeleton-line {
+    background: var(--border-dark);
+  }
+
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+  }
+
+  .ew-logo {
+    width: 56px;
+    height: 56px;
+    object-fit: contain;
+    margin-bottom: 0.25rem;
+  }
+
+  .ew-name {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--text);
+    margin: 0;
+    line-height: 1.2;
+  }
+
+  :global(.dark) .ew-name {
+    color: var(--text-dark);
+  }
+
+  .ew-subtitle {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    margin: 0;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  :global(.dark) .ew-subtitle {
+    color: var(--text-secondary-dark);
+  }
+
+  .ew-error p {
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    margin: 0;
+  }
+
+  :global(.dark) .ew-error p {
+    color: var(--text-secondary-dark);
+  }
+
+  .remove-comparison-btn {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    background-color: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 50%;
+    cursor: pointer;
+    color: var(--text-tertiary);
+    opacity: 0.7;
+    transition: opacity 0.15s;
+  }
+
+  .remove-comparison-btn:hover {
+    opacity: 1;
+    color: var(--text-secondary);
+  }
+
+  :global(.dark) .remove-comparison-btn {
+    background-color: var(--bg-dark);
+    border-color: var(--border-dark);
+    color: var(--text-tertiary-dark);
+  }
+
+  :global(.dark) .remove-comparison-btn:hover {
+    color: var(--text-secondary-dark);
+  }
+
+  /* Mobile: stack vertically */
+  @media (max-width: 480px) {
+    .entity-pair-wrapper {
+      flex-direction: column;
+    }
+
+    .comparison-legend {
+      gap: 1rem;
+    }
+
+    .ew-logo {
+      width: 48px;
+      height: 48px;
+    }
+
+    .ew-name {
+      font-size: 0.95rem;
+    }
+  }
+</style>
+
+<script>
+  import { swrFetch, setPageData } from '../lib/utils/api-fetcher';
+
+  /**
+   * EntityWidgetComparisonManager
+   *
+   * Manages the comparison widget display, fetching data for both entities
+   * and handling the comparison state.
+   */
+  class EntityWidgetComparisonManager {
+    private container: HTMLElement | null = null;
+    private apiUrl: string = '';
+    private removeBtn: HTMLElement | null = null;
+
+    private primaryData: any = null;
+    private secondaryData: any = null;
+
+    constructor() {
+      this.container = document.getElementById('entity-widget-comparison');
+      if (!this.container) return;
+
+      const primaryWidget = document.getElementById('compare-primary-widget');
+      this.apiUrl = primaryWidget?.dataset.api || 'http://localhost:8000/api/v1';
+      this.removeBtn = document.getElementById('remove-comparison-btn');
+
+      this.bindEvents();
+      this.exposeAPI();
+    }
+
+    private bindEvents() {
+      this.removeBtn?.addEventListener('click', () => {
+        this.hide();
+        // Dispatch event for parent to handle
+        window.dispatchEvent(new CustomEvent('comparison:removed'));
+      });
+    }
+
+    private exposeAPI() {
+      (window as any).entityWidgetComparison = {
+        show: (
+          sport: string,
+          primaryType: string,
+          primaryId: string,
+          secondaryType: string,
+          secondaryId: string
+        ) => {
+          this.show(sport, primaryType, primaryId, secondaryType, secondaryId);
+        },
+        hide: () => this.hide(),
+        isVisible: () => this.isVisible(),
+        getPrimaryData: () => this.primaryData,
+        getSecondaryData: () => this.secondaryData,
+      };
+    }
+
+    public async show(
+      sport: string,
+      primaryType: string,
+      primaryId: string,
+      secondaryType: string,
+      secondaryId: string
+    ) {
+      if (!this.container) return;
+
+      // Show container
+      this.container.classList.remove('hidden');
+
+      // Fetch both entities in parallel
+      const [primaryResult, secondaryResult] = await Promise.all([
+        this.fetchEntity('compare-primary', primaryType, primaryId, sport),
+        this.fetchEntity('compare-secondary', secondaryType, secondaryId, sport),
+      ]);
+
+      this.primaryData = primaryResult;
+      this.secondaryData = secondaryResult;
+
+      // Update legend names
+      this.updateLegend();
+
+      // Share data with other components
+      setPageData('comparisonWidget', {
+        primary: this.primaryData,
+        secondary: this.secondaryData,
+      });
+    }
+
+    private async fetchEntity(
+      prefix: string,
+      type: string,
+      id: string,
+      sport: string
+    ): Promise<any> {
+      const url = `${this.apiUrl}/widget/${type}/${id}?sport=${sport.toUpperCase()}`;
+
+      try {
+        const { data } = await swrFetch<Record<string, unknown>>(url, {
+          staleTime: 60 * 1000,
+          cacheTime: 30 * 60 * 1000,
+        });
+
+        if ((data as { error?: unknown }).error) {
+          this.showError(prefix);
+          return null;
+        }
+
+        this.renderEntity(prefix, data, type);
+        return data;
+      } catch {
+        this.showError(prefix);
+        return null;
+      }
+    }
+
+    private renderEntity(prefix: string, data: any, type: string) {
+      let name = '';
+      let logo = '';
+      let subtitle = '';
+
+      if (type === 'team') {
+        const teamData = data.team || {};
+        const venueData = data.venue || {};
+        name = teamData.name || 'Unknown';
+        logo = teamData.logo || '';
+        subtitle = venueData.name || teamData.city || teamData.country || '';
+      } else {
+        const playerData = data.player || {};
+        const stats = data.statistics || [];
+        const teamInfo = stats[0]?.team;
+        name = `${playerData.firstname || ''} ${playerData.lastname || ''}`.trim() || playerData.name || 'Unknown';
+        logo = playerData.photo || '';
+        subtitle = teamInfo?.name || playerData.position || '';
+      }
+
+      const nameEl = document.getElementById(`${prefix}-name`);
+      const subtitleEl = document.getElementById(`${prefix}-subtitle`);
+      const logoEl = document.getElementById(`${prefix}-logo`) as HTMLImageElement;
+
+      if (nameEl) nameEl.textContent = name;
+      if (subtitleEl) subtitleEl.textContent = subtitle;
+
+      if (logoEl && logo) {
+        logoEl.src = logo;
+        logoEl.alt = name;
+        logoEl.style.display = 'block';
+      }
+
+      this.showContent(prefix);
+    }
+
+    private updateLegend() {
+      const primaryNameEl = document.getElementById('legend-primary-name');
+      const secondaryNameEl = document.getElementById('legend-secondary-name');
+
+      if (primaryNameEl && this.primaryData) {
+        const name = this.primaryData.team?.name ||
+          `${this.primaryData.player?.firstname || ''} ${this.primaryData.player?.lastname || ''}`.trim() ||
+          'Primary';
+        primaryNameEl.textContent = name;
+      }
+
+      if (secondaryNameEl && this.secondaryData) {
+        const name = this.secondaryData.team?.name ||
+          `${this.secondaryData.player?.firstname || ''} ${this.secondaryData.player?.lastname || ''}`.trim() ||
+          'Comparison';
+        secondaryNameEl.textContent = name;
+      }
+    }
+
+    private showContent(prefix: string) {
+      const loadingEl = document.getElementById(`${prefix}-loading`);
+      const contentEl = document.getElementById(`${prefix}-content`);
+      const errorEl = document.getElementById(`${prefix}-error`);
+
+      if (loadingEl) loadingEl.style.display = 'none';
+      if (contentEl) contentEl.style.display = 'flex';
+      if (errorEl) errorEl.style.display = 'none';
+    }
+
+    private showError(prefix: string) {
+      const loadingEl = document.getElementById(`${prefix}-loading`);
+      const contentEl = document.getElementById(`${prefix}-content`);
+      const errorEl = document.getElementById(`${prefix}-error`);
+
+      if (loadingEl) loadingEl.style.display = 'none';
+      if (contentEl) contentEl.style.display = 'none';
+      if (errorEl) errorEl.style.display = 'flex';
+    }
+
+    public hide() {
+      if (!this.container) return;
+      this.container.classList.add('hidden');
+      this.primaryData = null;
+      this.secondaryData = null;
+
+      // Reset loading states
+      ['compare-primary', 'compare-secondary'].forEach((prefix) => {
+        const loadingEl = document.getElementById(`${prefix}-loading`);
+        const contentEl = document.getElementById(`${prefix}-content`);
+        const errorEl = document.getElementById(`${prefix}-error`);
+
+        if (loadingEl) loadingEl.style.display = 'flex';
+        if (contentEl) contentEl.style.display = 'none';
+        if (errorEl) errorEl.style.display = 'none';
+      });
+    }
+
+    public isVisible(): boolean {
+      return this.container ? !this.container.classList.contains('hidden') : false;
+    }
+  }
+
+  // Initialize
+  new EntityWidgetComparisonManager();
+</script>

--- a/astro-frontend/src/components/StatsCardComparison.astro
+++ b/astro-frontend/src/components/StatsCardComparison.astro
@@ -1,0 +1,614 @@
+---
+/**
+ * Stats Card Comparison
+ *
+ * Displays statistics for two entities side-by-side for comparison.
+ * Shows colored bars for visual differentiation and a legend.
+ * Used on the entity page when comparison mode is active.
+ */
+
+interface Props {
+  title?: string;
+}
+
+const { title = "Statistics Comparison" } = Astro.props;
+const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
+---
+
+<div id="stats-card-comparison" class="stats-comparison-card card hidden" data-api-url={apiUrl}>
+  <!-- Header -->
+  <div class="stats-card-header">
+    <h3 class="stats-card-title">{title}</h3>
+    <span id="stats-comparison-season" class="stats-card-season"></span>
+  </div>
+
+  <!-- Legend -->
+  <div class="stats-comparison-legend">
+    <div class="legend-item">
+      <span class="legend-bar primary"></span>
+      <span id="stats-legend-primary" class="legend-name">Primary</span>
+    </div>
+    <div class="legend-item">
+      <span class="legend-bar secondary"></span>
+      <span id="stats-legend-secondary" class="legend-name">Comparison</span>
+    </div>
+  </div>
+
+  <!-- Content -->
+  <div class="stats-card-body">
+    <!-- Loading State -->
+    <div id="stats-comparison-loading" class="stats-loading">
+      <div class="skeleton-row">
+        <div class="skeleton-cell label"></div>
+        <div class="skeleton-cell bars"></div>
+      </div>
+      <div class="skeleton-row">
+        <div class="skeleton-cell label"></div>
+        <div class="skeleton-cell bars"></div>
+      </div>
+      <div class="skeleton-row">
+        <div class="skeleton-cell label"></div>
+        <div class="skeleton-cell bars"></div>
+      </div>
+      <div class="skeleton-row">
+        <div class="skeleton-cell label"></div>
+        <div class="skeleton-cell bars"></div>
+      </div>
+    </div>
+
+    <!-- Data Table -->
+    <div id="stats-comparison-content" class="stats-comparison-content hidden">
+      <div id="stats-comparison-rows" class="stats-rows">
+        <!-- Rows populated by JavaScript -->
+      </div>
+    </div>
+
+    <!-- Empty State -->
+    <div id="stats-comparison-empty" class="stats-empty hidden">
+      <p>No statistics available for comparison</p>
+    </div>
+
+    <!-- Error State -->
+    <div id="stats-comparison-error" class="stats-error hidden">
+      <p>Unable to load statistics</p>
+    </div>
+  </div>
+</div>
+
+<style>
+  .stats-comparison-card {
+    width: 100%;
+    max-width: 600px;
+    display: flex;
+    flex-direction: column;
+    border-radius: 0.375rem;
+    overflow: hidden;
+  }
+
+  .stats-comparison-card.hidden {
+    display: none;
+  }
+
+  .stats-card-header {
+    padding: 1.25rem 1.5rem 0.75rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .stats-card-title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text);
+    line-height: 1.4;
+  }
+
+  :global(.dark) .stats-card-title {
+    color: var(--text-dark);
+  }
+
+  .stats-card-season {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    font-weight: 500;
+  }
+
+  :global(.dark) .stats-card-season {
+    color: var(--text-secondary-dark);
+  }
+
+  .stats-comparison-legend {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+    padding: 0.5rem 1.5rem 0.75rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  :global(.dark) .stats-comparison-legend {
+    border-bottom-color: var(--border-dark);
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .legend-bar {
+    width: 16px;
+    height: 8px;
+    border-radius: 2px;
+  }
+
+  .legend-bar.primary {
+    background-color: var(--compare-primary);
+  }
+
+  .legend-bar.secondary {
+    background-color: var(--compare-secondary);
+  }
+
+  :global(.dark) .legend-bar.primary {
+    background-color: var(--compare-primary-dark);
+  }
+
+  :global(.dark) .legend-bar.secondary {
+    background-color: var(--compare-secondary-dark);
+  }
+
+  .legend-name {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    max-width: 100px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  :global(.dark) .legend-name {
+    color: var(--text-secondary-dark);
+  }
+
+  .stats-card-body {
+    padding: 1rem 1.5rem 1.25rem;
+  }
+
+  /* Loading Skeleton */
+  .stats-loading {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .skeleton-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem 0;
+  }
+
+  .skeleton-cell {
+    height: 14px;
+    border-radius: 3px;
+    background-color: var(--border);
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+
+  .skeleton-cell.label {
+    width: 30%;
+  }
+
+  .skeleton-cell.bars {
+    width: 60%;
+    height: 24px;
+  }
+
+  :global(.dark) .skeleton-cell {
+    background-color: var(--border-dark);
+  }
+
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+  }
+
+  /* Stats Rows */
+  .stats-rows {
+    display: flex;
+    flex-direction: column;
+  }
+
+  :global(.stats-comparison-row) {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    padding: 0.75rem 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  :global(.stats-comparison-row:last-child) {
+    border-bottom: none;
+  }
+
+  :global(.dark .stats-comparison-row) {
+    border-bottom-color: var(--border-dark);
+  }
+
+  :global(.stats-row-header) {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  :global(.stats-row-label) {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    font-weight: 400;
+  }
+
+  :global(.dark .stats-row-label) {
+    color: var(--text-secondary-dark);
+  }
+
+  :global(.stats-row-values) {
+    display: flex;
+    gap: 0.75rem;
+    font-size: 0.85rem;
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+  }
+
+  :global(.stats-value-primary) {
+    color: var(--compare-primary);
+  }
+
+  :global(.stats-value-secondary) {
+    color: var(--compare-secondary);
+  }
+
+  :global(.dark .stats-value-primary) {
+    color: var(--compare-primary-dark);
+  }
+
+  :global(.dark .stats-value-secondary) {
+    color: var(--compare-secondary-dark);
+  }
+
+  :global(.stats-bars-container) {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  :global(.stats-bar-row) {
+    display: flex;
+    align-items: center;
+    height: 12px;
+  }
+
+  :global(.stats-bar) {
+    height: 100%;
+    border-radius: 2px;
+    min-width: 4px;
+    transition: width 0.3s ease;
+  }
+
+  :global(.stats-bar.primary) {
+    background-color: var(--compare-primary);
+  }
+
+  :global(.stats-bar.secondary) {
+    background-color: var(--compare-secondary);
+  }
+
+  :global(.dark .stats-bar.primary) {
+    background-color: var(--compare-primary-dark);
+  }
+
+  :global(.dark .stats-bar.secondary) {
+    background-color: var(--compare-secondary-dark);
+  }
+
+  /* Empty & Error States */
+  .stats-empty,
+  .stats-error {
+    padding: 1.5rem 0;
+    text-align: center;
+  }
+
+  .stats-empty p,
+  .stats-error p {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--text-tertiary);
+  }
+
+  :global(.dark) .stats-empty p,
+  :global(.dark) .stats-error p {
+    color: var(--text-tertiary-dark);
+  }
+
+  .hidden {
+    display: none !important;
+  }
+
+  /* Responsive */
+  @media (max-width: 480px) {
+    .stats-card-header {
+      padding: 1rem;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.25rem;
+    }
+
+    .stats-card-title {
+      font-size: 0.9rem;
+    }
+
+    .stats-comparison-legend {
+      padding: 0.5rem 1rem 0.75rem;
+      gap: 1rem;
+    }
+
+    .stats-card-body {
+      padding: 0.75rem 1rem 1rem;
+    }
+
+    :global(.stats-comparison-row) {
+      padding: 0.625rem 0;
+    }
+
+    :global(.stats-row-label) {
+      font-size: 0.8rem;
+    }
+
+    :global(.stats-row-values) {
+      font-size: 0.8rem;
+    }
+  }
+</style>
+
+<script>
+  import { escapeHtml } from '../lib/utils/dom';
+  import { swrFetch } from '../lib/utils/api-fetcher';
+
+  /**
+   * StatsCardComparisonManager
+   *
+   * Manages the comparison stats card, fetching and displaying
+   * stats for both entities with visual comparison bars.
+   */
+  class StatsCardComparisonManager {
+    private card: HTMLElement | null = null;
+    private apiUrl: string = '';
+
+    private primaryStats: Array<{ label: string; value: string | number }> = [];
+    private secondaryStats: Array<{ label: string; value: string | number }> = [];
+    private primaryName: string = 'Primary';
+    private secondaryName: string = 'Comparison';
+
+    constructor() {
+      this.card = document.getElementById('stats-card-comparison');
+      if (!this.card) return;
+
+      this.apiUrl = this.card.dataset.apiUrl || '';
+      this.exposeAPI();
+    }
+
+    private exposeAPI() {
+      (window as any).statsCardComparison = {
+        show: (
+          sport: string,
+          primaryType: string,
+          primaryId: string,
+          secondaryType: string,
+          secondaryId: string,
+          primaryName?: string,
+          secondaryName?: string
+        ) => {
+          this.primaryName = primaryName || 'Primary';
+          this.secondaryName = secondaryName || 'Comparison';
+          this.show(sport, primaryType, primaryId, secondaryType, secondaryId);
+        },
+        hide: () => this.hide(),
+        isVisible: () => this.isVisible(),
+      };
+    }
+
+    public async show(
+      sport: string,
+      primaryType: string,
+      primaryId: string,
+      secondaryType: string,
+      secondaryId: string
+    ) {
+      if (!this.card) return;
+
+      // Show card and loading state
+      this.card.classList.remove('hidden');
+      this.showLoading();
+
+      // Update legend names
+      const primaryLegendEl = document.getElementById('stats-legend-primary');
+      const secondaryLegendEl = document.getElementById('stats-legend-secondary');
+      if (primaryLegendEl) primaryLegendEl.textContent = this.primaryName;
+      if (secondaryLegendEl) secondaryLegendEl.textContent = this.secondaryName;
+
+      // Fetch both stats in parallel
+      const [primaryResult, secondaryResult] = await Promise.all([
+        this.fetchStats(sport, primaryType, primaryId),
+        this.fetchStats(sport, secondaryType, secondaryId),
+      ]);
+
+      if (!primaryResult && !secondaryResult) {
+        this.showError();
+        return;
+      }
+
+      if ((!primaryResult?.stats || primaryResult.stats.length === 0) &&
+          (!secondaryResult?.stats || secondaryResult.stats.length === 0)) {
+        this.showEmpty();
+        return;
+      }
+
+      this.primaryStats = primaryResult?.stats || [];
+      this.secondaryStats = secondaryResult?.stats || [];
+
+      // Update season
+      const season = primaryResult?.season || secondaryResult?.season;
+      if (season) {
+        const seasonEl = document.getElementById('stats-comparison-season');
+        if (seasonEl) seasonEl.textContent = `${season} Season`;
+      }
+
+      this.renderComparison();
+    }
+
+    private async fetchStats(
+      sport: string,
+      type: string,
+      id: string
+    ): Promise<{ stats: Array<{ label: string; value: string | number }>; season?: string } | null> {
+      const url = `${this.apiUrl}/stats/${type}/${id}?sport=${sport}`;
+
+      try {
+        const { data } = await swrFetch<{
+          stats?: Array<{ label: string; value: string | number }>;
+          season?: string;
+        }>(url, {
+          staleTime: 5 * 60 * 1000,
+          cacheTime: 30 * 60 * 1000,
+        });
+
+        if (!data || !data.stats) {
+          return null;
+        }
+
+        return { stats: data.stats, season: data.season };
+      } catch {
+        return null;
+      }
+    }
+
+    private renderComparison() {
+      const rowsEl = document.getElementById('stats-comparison-rows');
+      if (!rowsEl) return;
+
+      // Create a merged list of all stats labels
+      const allLabels = new Set<string>();
+      this.primaryStats.forEach(s => allLabels.add(s.label));
+      this.secondaryStats.forEach(s => allLabels.add(s.label));
+
+      // Create lookup maps
+      const primaryMap = new Map(this.primaryStats.map(s => [s.label, s.value]));
+      const secondaryMap = new Map(this.secondaryStats.map(s => [s.label, s.value]));
+
+      // Render rows
+      const rows: string[] = [];
+      allLabels.forEach(label => {
+        const primaryValue = primaryMap.get(label);
+        const secondaryValue = secondaryMap.get(label);
+
+        // Parse numeric values for bar calculation
+        const primaryNum = this.parseNumericValue(primaryValue);
+        const secondaryNum = this.parseNumericValue(secondaryValue);
+
+        // Calculate bar widths (as percentage of max)
+        let primaryWidth = 0;
+        let secondaryWidth = 0;
+
+        if (primaryNum !== null || secondaryNum !== null) {
+          const max = Math.max(primaryNum || 0, secondaryNum || 0);
+          if (max > 0) {
+            primaryWidth = primaryNum !== null ? (primaryNum / max) * 100 : 0;
+            secondaryWidth = secondaryNum !== null ? (secondaryNum / max) * 100 : 0;
+          }
+        }
+
+        const primaryDisplay = primaryValue !== undefined ? String(primaryValue) : '-';
+        const secondaryDisplay = secondaryValue !== undefined ? String(secondaryValue) : '-';
+
+        rows.push(`
+          <div class="stats-comparison-row">
+            <div class="stats-row-header">
+              <span class="stats-row-label">${escapeHtml(label)}</span>
+              <span class="stats-row-values">
+                <span class="stats-value-primary">${escapeHtml(primaryDisplay)}</span>
+                <span style="color: var(--text-tertiary)">vs</span>
+                <span class="stats-value-secondary">${escapeHtml(secondaryDisplay)}</span>
+              </span>
+            </div>
+            <div class="stats-bars-container">
+              <div class="stats-bar-row">
+                <div class="stats-bar primary" style="width: ${primaryWidth}%"></div>
+              </div>
+              <div class="stats-bar-row">
+                <div class="stats-bar secondary" style="width: ${secondaryWidth}%"></div>
+              </div>
+            </div>
+          </div>
+        `);
+      });
+
+      rowsEl.innerHTML = rows.join('');
+      this.showContent();
+    }
+
+    private parseNumericValue(value: string | number | undefined): number | null {
+      if (value === undefined || value === null || value === '-') return null;
+
+      // Handle string values
+      if (typeof value === 'string') {
+        // Remove common suffixes like %, etc.
+        const cleaned = value.replace(/[%,]/g, '').trim();
+        const num = parseFloat(cleaned);
+        return isNaN(num) ? null : num;
+      }
+
+      return typeof value === 'number' ? value : null;
+    }
+
+    private showLoading() {
+      this.card?.querySelector('#stats-comparison-loading')?.classList.remove('hidden');
+      this.card?.querySelector('#stats-comparison-content')?.classList.add('hidden');
+      this.card?.querySelector('#stats-comparison-empty')?.classList.add('hidden');
+      this.card?.querySelector('#stats-comparison-error')?.classList.add('hidden');
+    }
+
+    private showContent() {
+      this.card?.querySelector('#stats-comparison-loading')?.classList.add('hidden');
+      this.card?.querySelector('#stats-comparison-content')?.classList.remove('hidden');
+      this.card?.querySelector('#stats-comparison-empty')?.classList.add('hidden');
+      this.card?.querySelector('#stats-comparison-error')?.classList.add('hidden');
+    }
+
+    private showEmpty() {
+      this.card?.querySelector('#stats-comparison-loading')?.classList.add('hidden');
+      this.card?.querySelector('#stats-comparison-content')?.classList.add('hidden');
+      this.card?.querySelector('#stats-comparison-empty')?.classList.remove('hidden');
+      this.card?.querySelector('#stats-comparison-error')?.classList.add('hidden');
+    }
+
+    private showError() {
+      this.card?.querySelector('#stats-comparison-loading')?.classList.add('hidden');
+      this.card?.querySelector('#stats-comparison-content')?.classList.add('hidden');
+      this.card?.querySelector('#stats-comparison-empty')?.classList.add('hidden');
+      this.card?.querySelector('#stats-comparison-error')?.classList.remove('hidden');
+    }
+
+    public hide() {
+      this.card?.classList.add('hidden');
+      this.primaryStats = [];
+      this.secondaryStats = [];
+    }
+
+    public isVisible(): boolean {
+      return this.card ? !this.card.classList.contains('hidden') : false;
+    }
+  }
+
+  // Initialize
+  new StatsCardComparisonManager();
+</script>

--- a/astro-frontend/src/lib/utils/api-fetcher.ts
+++ b/astro-frontend/src/lib/utils/api-fetcher.ts
@@ -194,6 +194,7 @@ interface PageData {
   widget?: unknown;
   news?: unknown;
   stats?: unknown;
+  comparisonWidget?: unknown;
 }
 
 const pageDataStore: PageData = {};

--- a/astro-frontend/src/pages/entity.astro
+++ b/astro-frontend/src/pages/entity.astro
@@ -2,17 +2,30 @@
 import Layout from '../layouts/Layout.astro';
 import EntityWidget from '../components/EntityWidget.astro';
 import StatsCard from '../components/StatsCard.astro';
+import ComparisonSearchModal from '../components/ComparisonSearchModal.astro';
+import EntityWidgetComparison from '../components/EntityWidgetComparison.astro';
+import StatsCardComparison from '../components/StatsCardComparison.astro';
 ---
 
-<Layout 
+<Layout
   title="Entity Profile - Scoracle"
   description="View detailed statistics, news, and information about sports players and teams"
 >
   <main class="entity-main">
-    <EntityWidget page="entity" />
-    
-    <!-- Stats Card -->
-    <StatsCard title="Statistics" />
+    <!-- Single Entity View (default) -->
+    <div id="single-entity-view">
+      <EntityWidget page="entity" showCompareButton={true} />
+      <StatsCard title="Statistics" />
+    </div>
+
+    <!-- Comparison View (hidden by default) -->
+    <div id="comparison-view" class="comparison-view hidden">
+      <EntityWidgetComparison />
+      <StatsCardComparison title="Statistics Comparison" />
+    </div>
+
+    <!-- Comparison Search Modal -->
+    <ComparisonSearchModal />
   </main>
 </Layout>
 
@@ -30,4 +43,215 @@ import StatsCard from '../components/StatsCard.astro';
   :global(.dark) .entity-main {
     background-color: var(--bg-dark);
   }
+
+  #single-entity-view {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+    width: 100%;
+  }
+
+  #single-entity-view.hidden {
+    display: none;
+  }
+
+  .comparison-view {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+    width: 100%;
+  }
+
+  .comparison-view.hidden {
+    display: none;
+  }
 </style>
+
+<script>
+  import type { AutocompleteEntity } from '../lib/utils/autocomplete';
+
+  /**
+   * Entity Page Comparison Manager
+   *
+   * Orchestrates the comparison feature on the entity page.
+   * Handles switching between single and comparison views.
+   */
+  class EntityPageManager {
+    private singleView: HTMLElement | null = null;
+    private comparisonView: HTMLElement | null = null;
+
+    private primarySport: string = '';
+    private primaryType: string = '';
+    private primaryId: string = '';
+    private primaryName: string = '';
+
+    private secondaryType: string = '';
+    private secondaryId: string = '';
+    private secondaryName: string = '';
+
+    constructor() {
+      this.singleView = document.getElementById('single-entity-view');
+      this.comparisonView = document.getElementById('comparison-view');
+
+      this.bindEvents();
+    }
+
+    private bindEvents() {
+      // Listen for comparison add request (from EntityWidget + button)
+      window.addEventListener('comparison:add', ((event: CustomEvent) => {
+        const { sport, type, id, name } = event.detail;
+        this.primarySport = sport;
+        this.primaryType = type;
+        this.primaryId = id;
+        this.primaryName = name;
+
+        this.openComparisonModal();
+      }) as EventListener);
+
+      // Listen for comparison removal
+      window.addEventListener('comparison:removed', () => {
+        this.exitComparisonMode();
+      });
+    }
+
+    private openComparisonModal() {
+      // Use the global comparison modal API
+      const modal = (window as any).comparisonModal;
+      if (modal) {
+        modal.open(
+          this.primarySport,
+          this.primaryType,
+          this.primaryId,
+          (entity: AutocompleteEntity) => {
+            this.onComparisonSelected(entity);
+          }
+        );
+      }
+    }
+
+    private onComparisonSelected(entity: AutocompleteEntity) {
+      this.secondaryType = entity.type;
+      this.secondaryId = entity.id;
+      this.secondaryName = entity.name;
+
+      this.enterComparisonMode();
+    }
+
+    private enterComparisonMode() {
+      // Hide single view
+      this.singleView?.classList.add('hidden');
+
+      // Show comparison view
+      this.comparisonView?.classList.remove('hidden');
+
+      // Initialize comparison widgets
+      const widgetComparison = (window as any).entityWidgetComparison;
+      if (widgetComparison) {
+        widgetComparison.show(
+          this.primarySport,
+          this.primaryType,
+          this.primaryId,
+          this.secondaryType,
+          this.secondaryId
+        );
+      }
+
+      // Initialize comparison stats card
+      const statsComparison = (window as any).statsCardComparison;
+      if (statsComparison) {
+        statsComparison.show(
+          this.primarySport,
+          this.primaryType,
+          this.primaryId,
+          this.secondaryType,
+          this.secondaryId,
+          this.primaryName,
+          this.secondaryName
+        );
+      }
+
+      // Update URL with comparison params (for sharing/bookmarking)
+      this.updateURL();
+    }
+
+    private exitComparisonMode() {
+      // Show single view
+      this.singleView?.classList.remove('hidden');
+
+      // Hide comparison view
+      this.comparisonView?.classList.add('hidden');
+
+      // Hide comparison components
+      const widgetComparison = (window as any).entityWidgetComparison;
+      if (widgetComparison) widgetComparison.hide();
+
+      const statsComparison = (window as any).statsCardComparison;
+      if (statsComparison) statsComparison.hide();
+
+      // Reset secondary entity
+      this.secondaryType = '';
+      this.secondaryId = '';
+      this.secondaryName = '';
+
+      // Remove comparison params from URL
+      this.removeComparisonFromURL();
+    }
+
+    private updateURL() {
+      const url = new URL(window.location.href);
+      url.searchParams.set('compareType', this.secondaryType);
+      url.searchParams.set('compareId', this.secondaryId);
+      window.history.replaceState({}, '', url.toString());
+    }
+
+    private removeComparisonFromURL() {
+      const url = new URL(window.location.href);
+      url.searchParams.delete('compareType');
+      url.searchParams.delete('compareId');
+      window.history.replaceState({}, '', url.toString());
+    }
+
+    /**
+     * Check if comparison params exist in URL and restore comparison mode
+     */
+    private checkURLForComparison() {
+      const params = new URLSearchParams(window.location.search);
+      const compareType = params.get('compareType');
+      const compareId = params.get('compareId');
+
+      if (compareType && compareId) {
+        // Wait for entity widget to load and provide primary entity info
+        const checkWidget = () => {
+          const widget = (window as any).entityWidget;
+          if (widget && widget.getSport()) {
+            this.primarySport = widget.getSport();
+            this.primaryType = widget.getType();
+            this.primaryId = widget.getId();
+            this.primaryName = widget.getName() || 'Primary';
+
+            this.secondaryType = compareType;
+            this.secondaryId = compareId;
+            this.secondaryName = 'Comparison';
+
+            this.enterComparisonMode();
+          } else {
+            // Retry after a short delay
+            setTimeout(checkWidget, 100);
+          }
+        };
+
+        setTimeout(checkWidget, 200);
+      }
+    }
+  }
+
+  // Initialize
+  const manager = new EntityPageManager();
+
+  // Check for comparison in URL after page load
+  document.addEventListener('DOMContentLoaded', () => {
+    (manager as any).checkURLForComparison();
+  });
+</script>

--- a/astro-frontend/src/styles/global.css
+++ b/astro-frontend/src/styles/global.css
@@ -28,6 +28,18 @@
   --border-dark: #2e2e2e;
   --accent-dark: #e8e8e8;
   --accent-muted-dark: #cccccc;
+
+  /* Comparison colors - subtle, distinguishable */
+  --compare-primary: #2563eb;
+  --compare-primary-bg: #dbeafe;
+  --compare-secondary: #dc2626;
+  --compare-secondary-bg: #fee2e2;
+
+  /* Comparison colors - dark mode */
+  --compare-primary-dark: #60a5fa;
+  --compare-primary-bg-dark: #1e3a5f;
+  --compare-secondary-dark: #f87171;
+  --compare-secondary-bg-dark: #5f1e1e;
 }
 
 * {


### PR DESCRIPTION
- Add ComparisonSearchModal for searching and selecting comparison entities
- Add EntityWidgetComparison showing two entities side-by-side with color indicators
- Add StatsCardComparison with visual comparison bars and legend
- Update EntityWidget with a (+) button to trigger comparison mode
- Add comparison color variables (blue/red) to global CSS
- Update entity page to orchestrate single vs comparison views
- Support URL params for sharing comparison links

The feature allows users to click (+) on an entity page, search for another
entity of the same type/sport, and see their stats compared side-by-side
with colored bars for visual differentiation.