### PR TITLE
fix: Filter comparison search to show only same-type entities

### DIFF
--- a/astro-frontend/src/components/ComparisonSearchModal.astro
+++ b/astro-frontend/src/components/ComparisonSearchModal.astro
@@ -339,6 +339,7 @@
           suggestionsEl: this.suggestionsEl,
           initialSport: this.currentSport,
           itemClass: 'comparison-suggestion-item',
+          typeFilter: this.currentType as 'player' | 'team',
           renderItem: (entity, index) => `
             <button
               type="button"
@@ -351,12 +352,8 @@
             </button>
           `,
           onSelect: (entity) => {
-            // Filter: must be same type and not the same entity
-            if (entity.type !== this.currentType) {
-              return; // Should not happen due to filtering, but safety check
-            }
+            // Don't allow comparing with self
             if (entity.id === this.currentId) {
-              // Can't compare with self
               return;
             }
             this.close();
@@ -366,8 +363,9 @@
           },
         });
       } else {
-        // Update sport if changed
+        // Update sport and type filter if changed
         this.autocomplete.setSport(this.currentSport);
+        this.autocomplete.setTypeFilter(this.currentType as 'player' | 'team');
       }
 
       // Clear input


### PR DESCRIPTION
- Add typeFilter option to AutocompleteManager to filter by entity type
- Update ComparisonSearchModal to use typeFilter when searching
- Now only shows teams when comparing teams, players when comparing players
- This fixes the issue where selecting a different entity type did nothing