### PR TITLE
fix: Add pyahocorasick to api/requirements.txt for Vercel deployment

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,4 +8,5 @@ aiosqlite>=0.19.0
 rapidfuzz>=3.9.7
 feedparser>=6.0.10
 mangum>=0.17.0
+pyahocorasick>=2.0.0
 


### PR DESCRIPTION
The pyahocorasick library was added to backend/requirements.txt but not synced to api/requirements.txt, which is the file Vercel uses for serverless function dependencies.