### PR TITLE
Fix frontend not displaying backend data

### DIFF
--- a/astro-frontend/src/components/ContentCard.astro
+++ b/astro-frontend/src/components/ContentCard.astro
@@ -494,7 +494,7 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
           } catch {
             // EntityWidget hasn't loaded data yet - fetch ourselves using SWR
             // SWR will deduplicate if EntityWidget also requests the same URL
-            const url = `${this.apiUrl}/widget/info/${this.type}/${this.id}?sport=${this.sport!.toUpperCase()}`;
+            const url = `${this.apiUrl}/widget/profile/${this.type}/${this.id}?sport=${this.sport!.toUpperCase()}`;
             const { data } = await swrFetch<Record<string, unknown>>(url, CACHE_PRESETS.widget);
             widgetData = data;
             setPageData('widget', data);

--- a/astro-frontend/src/components/EntityWidget.astro
+++ b/astro-frontend/src/components/EntityWidget.astro
@@ -3,7 +3,7 @@
  * Entity Widget Island
  *
  * Lightweight component hydrated by backend JSON.
- * Fetches: GET /api/v1/entity/{type}/{id}?sport={sport}&include=widget
+ * Fetches: GET /api/v1/widget/profile/{type}/{id}?sport={sport}
  */
 
 interface Props {
@@ -417,7 +417,7 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
     }
 
     private async fetchData() {
-      const url = `${this.apiUrl}/widget/info/${this.type}/${this.id}?sport=${this.sport!.toUpperCase()}`;
+      const url = `${this.apiUrl}/widget/profile/${this.type}/${this.id}?sport=${this.sport!.toUpperCase()}`;
 
       try {
         // Use SWR fetch for caching and deduplication
@@ -447,7 +447,7 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
       let details: { label: string; value: string }[] = [];
 
       if (this.type === 'team') {
-        // New API returns flat team data from /widget/info/team/{id}
+        // New API returns flat team data from /widget/profile/team/{id}
         name = data.name || 'Unknown';
         logo = data.logo || '';
         subtitle = data.venue_name || data.city || '';
@@ -466,7 +466,7 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
           details.push({ label: 'Coach', value: data.coach });
         }
       } else {
-        // New API returns flat player data from /widget/info/player/{id}
+        // New API returns flat player data from /widget/profile/player/{id}
         name = `${data.firstname || ''} ${data.lastname || ''}`.trim() || data.name || 'Unknown';
         logo = data.photo || '';
         subtitle = data.team_name || '';

--- a/astro-frontend/src/components/EntityWidgetComparison.astro
+++ b/astro-frontend/src/components/EntityWidgetComparison.astro
@@ -430,8 +430,8 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
       id: string,
       sport: string
     ): Promise<any> {
-      // Use new widget/info endpoint
-      const url = `${this.apiUrl}/widget/info/${type}/${id}?sport=${sport.toUpperCase()}`;
+      // Use widget/profile endpoint
+      const url = `${this.apiUrl}/widget/profile/${type}/${id}?sport=${sport.toUpperCase()}`;
 
       try {
         const { data } = await swrFetch<Record<string, unknown>>(url, {

--- a/astro-frontend/src/components/EntityWidgetPair.astro
+++ b/astro-frontend/src/components/EntityWidgetPair.astro
@@ -264,8 +264,8 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
     }
 
     private async fetchEntity(prefix: string, type: string, id: string): Promise<void> {
-      // Use new widget/info endpoint
-      const url = `${this.apiUrl}/widget/info/${type}/${id}?sport=${this.params.sport!.toUpperCase()}`;
+      // Use widget/profile endpoint
+      const url = `${this.apiUrl}/widget/profile/${type}/${id}?sport=${this.params.sport!.toUpperCase()}`;
 
       try {
         // Use SWR fetch for caching and deduplication

--- a/astro-frontend/src/components/SharedArticlesCard.astro
+++ b/astro-frontend/src/components/SharedArticlesCard.astro
@@ -291,8 +291,8 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
 
     private async getEntityName(type: string, id: string): Promise<string | null> {
       try {
-        // Use new widget/info endpoint
-        const url = `${this.apiUrl}/widget/info/${type}/${id}?sport=${this.params.sport!.toUpperCase()}`;
+        // Use widget/profile endpoint
+        const url = `${this.apiUrl}/widget/profile/${type}/${id}?sport=${this.params.sport!.toUpperCase()}`;
 
         // Use SWR fetch for widget data
         const { data } = await swrFetch<Record<string, unknown>>(url, {

--- a/astro-frontend/src/components/StatsCard.astro
+++ b/astro-frontend/src/components/StatsCard.astro
@@ -516,8 +516,8 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
     }
 
     private async loadStats(sport: string, type: string, id: string) {
-      // Use the new profile endpoint which returns stats + percentiles
-      const url = `${this.apiUrl}/widget/profile/${type}/${id}?sport=${sport.toUpperCase()}&include_percentiles=true`;
+      // Use the stats endpoint which returns stats + percentiles
+      const url = `${this.apiUrl}/widget/stats/${type}/${id}?sport=${sport.toUpperCase()}&include_percentiles=true`;
 
       const { data } = await swrFetch<{
         info?: Record<string, unknown>;

--- a/astro-frontend/src/components/StatsCardComparison.astro
+++ b/astro-frontend/src/components/StatsCardComparison.astro
@@ -471,8 +471,8 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
       type: string,
       id: string
     ): Promise<{ stats: Array<{ label: string; value: string | number }>; season?: string } | null> {
-      // Use new profile endpoint
-      const url = `${this.apiUrl}/widget/profile/${type}/${id}?sport=${sport.toUpperCase()}`;
+      // Use widget/stats endpoint
+      const url = `${this.apiUrl}/widget/stats/${type}/${id}?sport=${sport.toUpperCase()}`;
 
       try {
         const { data } = await swrFetch<{


### PR DESCRIPTION
- Changed all /widget/info/ calls to /widget/profile/
- Changed stats endpoint from /widget/profile/ to /widget/stats/
- Updated comments to reflect new endpoint names
- Affects EntityWidget, StatsCard, EntityWidgetPair, EntityWidgetComparison, StatsCardComparison, SharedArticlesCard, and ContentCard components

This fixes the issue where the frontend was not displaying data because it was calling outdated endpoint names.